### PR TITLE
options.process fires event on child components fix

### DIFF
--- a/src/withTrackingComponentDecorator.js
+++ b/src/withTrackingComponentDecorator.js
@@ -31,7 +31,7 @@ export default function withTrackingComponentDecorator(
           ? trackingData(props)
           : trackingData;
         this.contextTrackingData = (this.context.tracking && this.context.tracking.data) || {};
-        this.trackingData = merge({}, this.ownTrackingData, this.contextTrackingData);
+        this.trackingData = merge({}, this.contextTrackingData, this.ownTrackingData);
       }
 
       static displayName = `WithTracking(${decoratedComponentName})`;


### PR DESCRIPTION
This PR introduces fix for a bug discovered by @devorah here: https://github.com/nytm/seg-fe/pull/506#issuecomment-293012881

Basically when component with data that triggers `process` had child components decorated with `@track`, that coused dispatch of event with process trigger for every child.