### PR TITLE
[Feature] Access to component state data

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Alternatively, if you just want to just silence proptype errors when using [esli
 ### Usage as a Decorator
 `react-tracking` is best used as a `@decorator()` using the [babel decorators plugin](https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy).
 
-The decorator can be used on React Classes and on methods within those classes.
+The decorator can be used on React Classes and on methods within those classes. If you use it on methods within these classes, make sure to decorate the class as well. 
 
 ```js
 import React from 'react';
@@ -213,7 +213,7 @@ export default class FooButton extends React.Component {
 
   // In this case the tracking data depends on
   // some unknown (until runtime) value
-  @track((props, [event]) => ({
+  @track((props, state, [event]) => ({
     action: 'click',
     label: event.currentTarget.title || event.currentTarget.textContent
   }))
@@ -246,6 +246,20 @@ NOTE: That the above code utilizes some of the newer ES6 syntax. This is what it
     };
   })
 // ...
+```
+### Accessing data stored in the component's `props` and `state`
+
+Further runtime data, such as the component's `props` and `state`, are available as follows:
+
+```js
+  @track((props, state) => ({
+    action: state.following ? "unfollow clicked" : "follow clicked" 
+    name: props.name
+  }))
+  handleFollow = () => {
+     this.setState({ following: !this.state.following })
+    }
+  }
 ```
 
 #### Example `props.tracking.getTrackingData()` usage

--- a/src/__tests__/e2e.test.js
+++ b/src/__tests__/e2e.test.js
@@ -8,6 +8,7 @@ jest.setMock('../dispatchTrackingEvent', dispatchTrackingEvent);
 const testDataContext = { testDataContext: true };
 const testData = { testData: true };
 const dispatch = jest.fn();
+const testState = {booleanstate: true};
 
 describe('e2e', () => {
   // eslint-disable-next-line global-require
@@ -360,6 +361,35 @@ describe('e2e', () => {
       topLevel: true,
     });
     expect(dispatch).toHaveBeenCalledTimes(2); // pageview event and simulated button click
+  });
+
+  it('dispatches state data when components contain state', () => {
+    @track(testDataContext, { dispatch })
+    class TestOptions extends React.Component {
+      constructor() {
+        super()
+        this.state = {
+          booleanstate: true,
+        };
+      }
+
+      @track((props, state) => ({ booleanstate: state.booleanstate }))
+      exampleMethod = () => {}
+
+      render() {
+        this.exampleMethod();
+        return <div />;
+      }
+    }
+
+    mount(<TestOptions />);
+
+
+    expect(dispatchTrackingEvent).not.toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith({
+      ...testDataContext,
+      ...testState,
+    }); 
   });
 
   it('logs a console error when there is already a process defined on context', () => {

--- a/src/__tests__/e2e.test.js
+++ b/src/__tests__/e2e.test.js
@@ -8,7 +8,7 @@ jest.setMock('../dispatchTrackingEvent', dispatchTrackingEvent);
 const testDataContext = { testDataContext: true };
 const testData = { testData: true };
 const dispatch = jest.fn();
-const testState = {booleanstate: true};
+const testState = { booleanstate: true };
 
 describe('e2e', () => {
   // eslint-disable-next-line global-require
@@ -367,7 +367,7 @@ describe('e2e', () => {
     @track(testDataContext, { dispatch })
     class TestOptions extends React.Component {
       constructor() {
-        super()
+        super();
         this.state = {
           booleanstate: true,
         };
@@ -389,7 +389,7 @@ describe('e2e', () => {
     expect(dispatch).toHaveBeenCalledWith({
       ...testDataContext,
       ...testState,
-    }); 
+    });
   });
 
   it('logs a console error when there is already a process defined on context', () => {

--- a/src/__tests__/e2e.test.js
+++ b/src/__tests__/e2e.test.js
@@ -8,7 +8,7 @@ jest.setMock('../dispatchTrackingEvent', dispatchTrackingEvent);
 const testDataContext = { testDataContext: true };
 const testData = { testData: true };
 const dispatch = jest.fn();
-const testState = { booleanstate: true };
+const testState = { booleanState: true };
 
 describe('e2e', () => {
   // eslint-disable-next-line global-require
@@ -369,11 +369,11 @@ describe('e2e', () => {
       constructor() {
         super();
         this.state = {
-          booleanstate: true,
+          booleanState: true,
         };
       }
 
-      @track((props, state) => ({ booleanstate: state.booleanstate }))
+      @track((props, state) => ({ booleanState: state.booleanState }))
       exampleMethod = () => {}
 
       render() {

--- a/src/__tests__/trackEventMethodDecorator.test.js
+++ b/src/__tests__/trackEventMethodDecorator.test.js
@@ -79,7 +79,7 @@ describe('trackEventMethodDecorator', () => {
           },
         };
         this.state = {
-          myState: "someState",
+          myState: 'someState',
         };
       }
 

--- a/src/__tests__/trackEventMethodDecorator.test.js
+++ b/src/__tests__/trackEventMethodDecorator.test.js
@@ -91,13 +91,13 @@ describe('trackEventMethodDecorator', () => {
     myTC.handleTestEvent(dummyArgument);
 
     // Access the trackingData arguments
-    const trackingDataArguments = trackingData.mock.calls[0]
+    const trackingDataArguments = trackingData.mock.calls[0];
 
     expect(trackingData).toHaveBeenCalledTimes(1);
     expect(trackingDataArguments[0]).toEqual(myTC.props);
     expect(trackingDataArguments[1]).toEqual(myTC.state);
-    // We cannot compare the implicit arguments, as there is no constructor for objects of type argument
-    // Hence we make them explicit by turning them into arrays
+    // Here we have access to the raw `arguments` object, which is not an actual Array,
+    // so in order to compare, we convert the arguments to an array.
     expect(Array.from(trackingDataArguments[2])).toEqual([dummyArgument]);
 
     expect(trackEvent).toHaveBeenCalledWith(dummyData);

--- a/src/__tests__/trackEventMethodDecorator.test.js
+++ b/src/__tests__/trackEventMethodDecorator.test.js
@@ -63,4 +63,44 @@ describe('trackEventMethodDecorator', () => {
     expect(trackEvent).toHaveBeenCalledWith(dummyData);
     expect(spyTestEvent).toHaveBeenCalledWith('x');
   });
+
+  it('properly passes through the correct arguments when trackingData is a function', () => {
+    const dummyData = {};
+    const trackingData = jest.fn(() => dummyData);
+    const trackEvent = jest.fn();
+    const spyTestEvent = jest.fn();
+    const dummyArgument = 'x';
+
+    class TestClass {
+      constructor() {
+        this.props = {
+          tracking: {
+            trackEvent,
+          },
+        };
+        this.state = {
+          myState: "someState",
+        };
+      }
+
+      @trackEventMethodDecorator(trackingData)
+      handleTestEvent = spyTestEvent
+    }
+
+    const myTC = new TestClass();
+    myTC.handleTestEvent(dummyArgument);
+
+    // Access the trackingData arguments
+    const trackingDataArguments = trackingData.mock.calls[0]
+
+    expect(trackingData).toHaveBeenCalledTimes(1);
+    expect(trackingDataArguments[0]).toEqual(myTC.props);
+    expect(trackingDataArguments[1]).toEqual(myTC.state);
+    // We cannot compare the implicit arguments, as there is no constructor for objects of type argument
+    // Hence we make them explicit by turning them into arrays
+    expect(Array.from(trackingDataArguments[2])).toEqual([dummyArgument]);
+
+    expect(trackEvent).toHaveBeenCalledWith(dummyData);
+    expect(spyTestEvent).toHaveBeenCalledWith(dummyArgument);
+  });
 });

--- a/src/trackEventMethodDecorator.js
+++ b/src/trackEventMethodDecorator.js
@@ -5,7 +5,7 @@ export default function trackEventMethodDecorator(trackingData = {}) {
   return makeClassMemberDecorator(decoratedFn => function decorateClassMember() {
     if (this.props && this.props.tracking && typeof this.props.tracking.trackEvent === 'function') {
       const thisTrackingData = typeof trackingData === 'function'
-                ? trackingData(this.props, arguments)
+                ? trackingData(this.props, this.state, arguments)
                 : trackingData;
       this.props.tracking.trackEvent(thisTrackingData);
     }


### PR DESCRIPTION
Hiii 👋 

We've been very excited to integrate react-tracking into [our](https://github.com/artsy/reaction) [work](https://github.com/artsy/emission) over at [Artsy](https://www.artsy.net/)!

In our use of the library, we came the need to access the component's state, in order to pull out certain bits of data for our analytics. 

For example, when viewing an Artist's profile, there's a follow button which, [depending on the state, changes action and appearance](https://github.com/artsy/emission/blob/master/src/lib/Components/Artist/Header.tsx#L129-L141). When pressing this button, we would send the analytics events stating whether the user pressed "follow artist" or "unfollow artist", and this logic is captured in the component's state. 

<img width="363" alt="screen shot 2017-09-20 at 13 57 45" src="https://user-images.githubusercontent.com/373860/30644872-c1de469a-9e0b-11e7-8b0e-5b279287cf94.png">
<img width="368" alt="screen shot 2017-09-20 at 13 57 34" src="https://user-images.githubusercontent.com/373860/30644871-c1dd64a0-9e0b-11e7-8254-7ea3a9179c3d.png">


As such I've added [the ability](https://github.com/artsy/emission/blob/master/src/lib/Components/Artist/Header.tsx#L129) to also pull out state, as well as props, when implementing `@track()`. 

In code:

```
  @track((props, state) => ({ action: state.following ? "press unfollow button" : "press follow button" }))
  handleFollowChange() {
    // method body
  }
```

I'm aware that in this case the follow button could be implemented as its own component with props of course, but we do keep interesting internal details and data within `state` that we'd like to include in analytics throughout. 

Would you be open to this addition? If so I can also add some additions to the README for this case specifically, too :)!

