### PR TITLE
e2e test - will dispatch data even if the component is not wrapped with @track

### DIFF
--- a/src/__tests__/e2e.test.js
+++ b/src/__tests__/e2e.test.js
@@ -442,4 +442,22 @@ describe('e2e', () => {
 
     expect(global.console.error).toHaveBeenCalledTimes(1);
   });
+
+  it('will dispatch data even if the component is not wrapped with @track', () => {
+    class App extends React.Component {
+      @track({ event: 'buttonClick' }, { dispatch })
+      handleClick = jest.fn();
+
+      render() {
+        return <button onClick={this.handleClick} />;
+      }
+    }
+
+    const wrappedApp = mount(<App />);
+
+    wrappedApp.find('button').simulate('click');
+    expect(dispatch).toHaveBeenCalledWith({
+      event: 'buttonClick',
+    });
+  });
 });


### PR DESCRIPTION
Fail Case: #49
expect to be able to use `@track` within any component, event with the one that is not being wrapped with `@track` in component level
