### PR TITLE
Fix issue 59

### DIFF
--- a/src/__tests__/e2e.test.js
+++ b/src/__tests__/e2e.test.js
@@ -454,9 +454,9 @@ describe('e2e', () => {
     @track({ page: 'Page' })
     class Page extends React.Component {
       @track({ event: 'buttonClick' })
-      handleClick = jest.fn(); // eslint-disable-line jsx-a11y/no-static-element-interactions
+      handleClick = jest.fn();
       render() {
-        return <span onClick={this.handleClick}>Click Me</span>;
+        return <span onClick={this.handleClick}>Click Me</span>; // eslint-disable-line jsx-a11y/no-static-element-interactions
       }
     }
 

--- a/src/__tests__/e2e.test.js
+++ b/src/__tests__/e2e.test.js
@@ -453,9 +453,8 @@ describe('e2e', () => {
 
     @track({ page: 'Page' })
     class Page extends React.Component {
-      // eslint-disable-line jsx-a11y/no-static-element-interactions
       @track({ event: 'buttonClick' })
-      handleClick = jest.fn();
+      handleClick = jest.fn(); // eslint-disable-line jsx-a11y/no-static-element-interactions
       render() {
         return <span onClick={this.handleClick}>Click Me</span>;
       }

--- a/src/__tests__/e2e.test.js
+++ b/src/__tests__/e2e.test.js
@@ -453,6 +453,7 @@ describe('e2e', () => {
 
     @track({ page: 'Page' })
     class Page extends React.Component {
+      // eslint-disable-line jsx-a11y/no-static-element-interactions
       @track({ event: 'buttonClick' })
       handleClick = jest.fn();
       render() {

--- a/src/withTrackingComponentDecorator.js
+++ b/src/withTrackingComponentDecorator.js
@@ -30,17 +30,7 @@ export default function withTrackingComponentDecorator(
           );
         }
 
-        this.ownTrackingData =
-          typeof trackingData === 'function'
-            ? trackingData(props)
-            : trackingData;
-        this.contextTrackingData =
-          (this.context.tracking && this.context.tracking.data) || {};
-        this.trackingData = merge(
-          {},
-          this.contextTrackingData,
-          this.ownTrackingData
-        );
+        this.computeTrackingData(props, context);
       }
 
       static displayName = `WithTracking(${decoratedComponentName})`;
@@ -61,6 +51,20 @@ export default function withTrackingComponentDecorator(
       getTrackingDispatcher() {
         return (
           (this.context.tracking && this.context.tracking.dispatch) || dispatch
+        );
+      }
+
+      computeTrackingData(props, context) {
+        this.ownTrackingData =
+          typeof trackingData === 'function'
+            ? trackingData(props)
+            : trackingData;
+        this.contextTrackingData =
+          (context.tracking && context.tracking.data) || {};
+        this.trackingData = merge(
+          {},
+          this.contextTrackingData,
+          this.ownTrackingData
         );
       }
 
@@ -101,6 +105,10 @@ export default function withTrackingComponentDecorator(
         } else if (dispatchOnMount === true) {
           this.trackEvent();
         }
+      }
+
+      componentWillReceiveProps(nextProps, nextContext) {
+        this.computeTrackingData(nextProps, nextContext);
       }
 
       tracking = {


### PR DESCRIPTION
#59 
IMHO, you can either compute the tracking data lazily only when tracking is being called or eagerly whenever props changed.
Currently, the tracking data is being computed eagerly in the constructor, so for the minimal code change, i added the same computing call in the `componentWillReceiveProps`