### PR TITLE
Replace lodash.merge with deepmerge package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 coverage
 build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-tracking",
+  "name": "@dortzur/react-tracking",
   "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -1769,6 +1769,12 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "deepmerge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.0.1.tgz",
+      "integrity":
+        "sha512-VIPwiMJqJ13ZQfaCsIFnp5Me9tnjURiaIFxfz7EH0Ci0dTSQpZtSLrqOicXqEd/z2r+z+Klk9GzmnRsgpgbOsQ=="
     },
     "default-require-extensions": {
       "version": "1.0.0",
@@ -5560,7 +5566,8 @@
       "version": "4.6.0",
       "resolved":
         "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
+      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
+      "dev": true
     },
     "lodash.pick": {
       "version": "4.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dortzur/react-tracking",
+  "name": "react-tracking",
   "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dortzur/react-tracking",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Declarative tracking for React apps.",
   "author": "The New York Times",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@dortzur/react-tracking",
-  "version": "5.2.0",
+  "name": "react-tracking",
+  "version": "5.1.0",
   "description": "Declarative tracking for React apps.",
   "author": "The New York Times",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-tracking",
+  "name": "@dortzur/react-tracking",
   "version": "5.1.0",
   "description": "Declarative tracking for React apps.",
   "author": "The New York Times",
@@ -35,8 +35,8 @@
   "keywords": ["nyt", "react", "declarative", "tracking", "metrics", "layer"],
   "homepage": "https://github.com/NYTimes/react-tracking",
   "dependencies": {
-    "hoist-non-react-statics": "^2.3.1",
-    "lodash.merge": "^4.6.0"
+    "deepmerge": "^2.0.1",
+    "hoist-non-react-statics": "^2.3.1"
   },
   "peerDependencies": {
     "babel-runtime": "^6.20.0",

--- a/src/withTrackingComponentDecorator.js
+++ b/src/withTrackingComponentDecorator.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import merge from 'lodash.merge';
+import merge from 'deepmerge';
 import hoistNonReactStatic from 'hoist-non-react-statics';
 
 import dispatchTrackingEvent from './dispatchTrackingEvent';
@@ -44,7 +44,7 @@ export default function withTrackingComponentDecorator(
       trackEvent = data => {
         this.getTrackingDispatcher()(
           // deep-merge tracking data from context and tracking data passed in here
-          merge({}, this.trackingData, data)
+          merge(this.trackingData || {}, data || {})
         );
       };
 
@@ -62,16 +62,18 @@ export default function withTrackingComponentDecorator(
         this.contextTrackingData =
           (context.tracking && context.tracking.data) || {};
         this.trackingData = merge(
-          {},
-          this.contextTrackingData,
-          this.ownTrackingData
+          this.contextTrackingData || {},
+          this.ownTrackingData || {}
         );
       }
 
       getChildContext() {
         return {
           tracking: {
-            data: merge({}, this.contextTrackingData, this.ownTrackingData),
+            data: merge(
+              this.contextTrackingData || {},
+              this.ownTrackingData || {}
+            ),
             dispatch: this.getTrackingDispatcher(),
             process:
               (this.context.tracking && this.context.tracking.process) ||
@@ -90,9 +92,8 @@ export default function withTrackingComponentDecorator(
         ) {
           this.trackEvent(
             merge(
-              {},
-              contextProcess(this.ownTrackingData),
-              dispatchOnMount(this.trackingData)
+              contextProcess(this.ownTrackingData) || {},
+              dispatchOnMount(this.trackingData) || {}
             )
           );
         } else if (typeof contextProcess === 'function') {


### PR DESCRIPTION
Replacing lodash.merge with the deepmerge package significantly reduces bundle size.

https://bundlephobia.com/result?p=react-tracking@5.1.0 (6.3kb gzipped)
https://bundlephobia.com/result?p=@dortzur/react-tracking@5.2.1 (2.7kb gzipped)

Thanks for open sourcing this package by the way. 
