### PR TITLE
Fixing a small typo in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The `@track()` decorator will expose a `tracking` prop on the component it wraps
 This PropType is exported for use, if desired:
 
 ```js
-import { TrackingPropType } from 'react-tracking';
+import { TrackingProp } from 'react-tracking';
 ```
 
 Alternatively, if you just want to just silence proptype errors when using [eslint react/prop-types](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md), you can add this to your eslintrc:


### PR DESCRIPTION
Hi there,

At least in the latest version I grabbed from NPM, the PropType you expose is called `TrackingProp` and not `TrackingPropType`. I've just updated the docs to reflect that.

Thanks!