### PR TITLE
Track async method

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ npm install --save react-tracking
 ```
 
 ## Usage
-
 `@track()` expects two arguments, `trackingData` and `options`.
-
 - `trackingData` represents the data to be tracked (or a function returning that data)
 - `options` is an optional object that accepts three properties:
   - `dispatch`, which is a function to use instead of the default dispatch behavior. See the section on custom `dispatch()` later in this document.
@@ -38,7 +36,7 @@ The `@track()` decorator will expose a `tracking` prop on the component it wraps
 
     // function to call to grab contextual tracking data
     getTrackingData: PropTypes.func,
-  });
+  })
 }
 ```
 
@@ -53,16 +51,15 @@ Alternatively, if you want to just silence proptype errors when using [eslint re
 ```json
 {
   "rules": {
-    "react/prop-types": ["error", { "ignore": ["tracking"] }]
+    "react/prop-types" : ["error", { "ignore": ["tracking"] }]
   }
 }
 ```
 
 ### Usage as a Decorator
-
 `react-tracking` is best used as a `@decorator()` using the [babel decorators plugin](https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy).
 
-The decorator can be used on React Classes and on methods within those classes. If you use it on methods within these classes, make sure to decorate the class as well.
+The decorator can be used on React Classes and on methods within those classes. If you use it on methods within these classes, make sure to decorate the class as well. 
 
 ```js
 import React from 'react';
@@ -70,13 +67,18 @@ import track from 'react-tracking';
 
 @track({ page: 'FooPage' })
 export default class FooPage extends React.Component {
+
   @track({ action: 'click' })
   handleClick = () => {
     // ... other stuff
-  };
+  }
 
   render() {
-    return <button onClick={this.handleClick}>Click Me!</button>;
+    return (
+      <button onClick={this.handleClick}>
+        Click Me!
+      </button>
+    );
   }
 }
 ```
@@ -88,24 +90,23 @@ You can also track events by importing `track()` and wrapping your stateless fun
 ```js
 import track from 'react-tracking';
 
-const FooPage = props => {
+const FooPage = (props) => {
   return (
-    <div
-      onClick={() => {
+    <div onClick={() => {
         props.tracking.trackEvent({ action: 'click' });
 
         // ... other stuff
       }}
     />
-  );
-};
+  )
+}
 
 export default track({
-  page: 'FooPage',
+  page: 'FooPage'
 })(FooPage);
 ```
 
-This is also how you would use this module without `@decorators`, although this is obviously awkward and the decorator syntax is recommended.
+This is also how you would use this module without `@decorators`, although this is obviously awkward and the  decorator syntax is recommended.
 
 ### Custom `options.dispatch()` for tracking data
 
@@ -117,7 +118,7 @@ For example, to push objects to `window.myCustomDataLayer[]` instead, you would 
 import React, { Component } from 'react';
 import track from 'react-tracking';
 
-@track({}, { dispatch: data => window.myCustomDataLayer.push(data) })
+@track({}, { dispatch: (data) => window.myCustomDataLayer.push(data) })
 export default class App extends Component {
   render() {
     return this.props.children;
@@ -165,6 +166,7 @@ class FooPage extends Component { ... }
 
 Will dispatch the following data (assuming no other tracking data in context from the rest of the app):
 
+
 ```
 {
   event: 'pageDataReady',
@@ -174,7 +176,7 @@ Will dispatch the following data (assuming no other tracking data in context fro
 
 ### Top level `options.process`
 
-When there's a need to implicitly dispatch an event with some data for _every_ component, you can define an `options.process` function. This function should be declared once, at some top-level component. It will get called with each component's tracking data as the only argument. The returned object from this function will be merged with all the tracking context data and dispatched in `componentDidMount()`. If a falsy value is returned (`false`, `null`, `undefined`, ...), nothing will be dispatched.
+When there's a need to implicitly dispatch an event with some data for *every* component, you can define an `options.process` function. This function should be declared once, at some top-level component. It will get called with each component's tracking data as the only argument. The returned object from this function will be merged with all the tracking context data and dispatched in `componentDidMount()`. If a falsy value is returned (`false`, `null`, `undefined`, ...), nothing will be dispatched.
 
 A common use case for this is to dispatch a `pageview` event for every component in the application that has a `page` property on its `trackingData`:
 
@@ -196,13 +198,13 @@ When `Page2` mounts, nothing will be dispatched.
 
 ### Tracking Asynchronous Methods
 
-Asynchronous methods (methods that return promises) can also be tracked when the method has resolved or rejects a promise. This is handled transparently, so simply decorating an asynchronous method the same way as a normal method will make the tracking call _after_ the promise is resolved or rejected.
+Asynchronous methods (methods that return promises) can also be tracked when the method has resolved or rejects a promise. This is handled transparently, so simply decorating a asynchronous method the same way as a normal method will make the tracking call _after_ the promise is resolved or rejected.
 
 ```js
 // ...
   @track()
   async handleEvent() {
-    return await asyncCall(); // returns a promise
+    await asyncCall(); // returns a promise
   }
 // ...
 ```
@@ -227,25 +229,31 @@ import track from 'react-tracking';
 
 // In this case, the "page" tracking data
 // is a function of one of its props (isNew)
-@track(props => {
-  return { page: props.isNew ? 'new' : 'existing' };
+@track((props) => {
+  return { page: props.isNew ? 'new' : 'existing' }
 })
 export default class FooButton extends React.Component {
+
   // In this case the tracking data depends on
   // some unknown (until runtime) value
   @track((props, state, [event]) => ({
     action: 'click',
-    label: event.currentTarget.title || event.currentTarget.textContent,
+    label: event.currentTarget.title || event.currentTarget.textContent
   }))
-  handleClick = event => {
+  handleClick = (event) => {
     if (this.props.onClick) {
       this.props.onClick(event);
     }
-  };
+  }
 
   render() {
-    return <button onClick={this.handleClick}>{this.props.children}</button>;
+    return (
+      <button onClick={this.handleClick}>
+        {this.props.children}
+      </button>
+    );
   }
+
 }
 ```
 
@@ -294,7 +302,7 @@ Further runtime data, such as the component's `props` and `state`, are available
 
 ```js
   @track((props, state) => ({
-    action: state.following ? "unfollow clicked" : "follow clicked"
+    action: state.following ? "unfollow clicked" : "follow clicked" 
     name: props.name
   }))
   handleFollow = () => {
@@ -316,15 +324,18 @@ import track from 'react-tracking';
   const randomId = Math.floor(Math.random() * 100);
 
   return {
-    page_view_id: randomId,
-  };
+    page_view_id: randomId
+  }
 })
 export default class AdComponent extends React.Component {
   render() {
     const { page_view_id } = this.props.tracking.getTrackingData();
 
-    return <Ad pageViewId={page_view_id} />;
+    return (
+      <Ad pageViewId={page_view_id} />
+    );
   }
+
 }
 ```
 
@@ -339,3 +350,4 @@ This library simply merges the tracking data objects together (as it flows throu
 ### TypeScript Support
 
 You can get the type definitions for React Tracking from DefinitelyTyped using `@types/react-tracking`. For an always up-to-date example of syntax, you should consult [the react-tracking type tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-tracking/test/react-tracking-with-types-tests.tsx).
+

--- a/README.md
+++ b/README.md
@@ -196,6 +196,28 @@ class Page2 extends Component {...}
 When `Page1` mounts, event with data `{page: 'Page1', event: 'pageview'}` will be dispatched.
 When `Page2` mounts, nothing will be dispatched.
 
+### Tracking Asynchronous Methods
+
+Asynchronous methods (methods that return promises) can also be tracked when the method has resolved or rejects a promise. This is handled transparently, so simply decorating a asynchronous method the same way as a normal method will make the tracking call _after_ the promise is resolved or rejected.
+
+```js
+// ...
+  @track()
+  async handleEvent() {
+    await asyncCall(); // returns a promise
+  }
+// ...
+```
+
+Or without async/await syntax:
+
+````js
+// ...
+  @track()
+  handleEvent() {
+    return asyncCall(); // returns a promise
+  }
+
 ### Advanced Usage
 
 You can also pass a function as an argument instead of an object literal, which allows for some advanced usage scenarios such as when your tracking data is a function of some runtime values, like so:

--- a/README.md
+++ b/README.md
@@ -211,12 +211,13 @@ Asynchronous methods (methods that return promises) can also be tracked when the
 
 Or without async/await syntax:
 
-````js
+```js
 // ...
   @track()
   handleEvent() {
     return asyncCall(); // returns a promise
   }
+```
 
 ### Advanced Usage
 
@@ -269,6 +270,32 @@ NOTE: That the above code utilizes some of the newer ES6 syntax. This is what it
   })
 // ...
 ```
+
+When tracking asynchronous methods, you can also receive the resolved or rejected data from the returned promise in the fourth argument of the function passed in for tracking:
+
+```js
+// ...
+  @track((props, state, methodArgs, [{ value }, err]) => {
+    if (err) { // promise was rejected
+      return {
+        label: 'async action',
+        status: 'error',
+        value: err
+      };
+    }
+    return {
+      label: 'async action',
+      status: 'success',
+      value // value is "test"
+    };
+  })
+  handleAsyncAction(data) {
+    // ...
+    return Promise.resolve({ value: 'test' });
+  }
+// ...
+```
+
 ### Accessing data stored in the component's `props` and `state`
 
 Further runtime data, such as the component's `props` and `state`, are available as follows:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ npm install --save react-tracking
 ```
 
 ## Usage
+
 `@track()` expects two arguments, `trackingData` and `options`.
+
 - `trackingData` represents the data to be tracked (or a function returning that data)
 - `options` is an optional object that accepts three properties:
   - `dispatch`, which is a function to use instead of the default dispatch behavior. See the section on custom `dispatch()` later in this document.
@@ -36,7 +38,7 @@ The `@track()` decorator will expose a `tracking` prop on the component it wraps
 
     // function to call to grab contextual tracking data
     getTrackingData: PropTypes.func,
-  })
+  });
 }
 ```
 
@@ -51,15 +53,16 @@ Alternatively, if you want to just silence proptype errors when using [eslint re
 ```json
 {
   "rules": {
-    "react/prop-types" : ["error", { "ignore": ["tracking"] }]
+    "react/prop-types": ["error", { "ignore": ["tracking"] }]
   }
 }
 ```
 
 ### Usage as a Decorator
+
 `react-tracking` is best used as a `@decorator()` using the [babel decorators plugin](https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy).
 
-The decorator can be used on React Classes and on methods within those classes. If you use it on methods within these classes, make sure to decorate the class as well. 
+The decorator can be used on React Classes and on methods within those classes. If you use it on methods within these classes, make sure to decorate the class as well.
 
 ```js
 import React from 'react';
@@ -67,18 +70,13 @@ import track from 'react-tracking';
 
 @track({ page: 'FooPage' })
 export default class FooPage extends React.Component {
-
   @track({ action: 'click' })
   handleClick = () => {
     // ... other stuff
-  }
+  };
 
   render() {
-    return (
-      <button onClick={this.handleClick}>
-        Click Me!
-      </button>
-    );
+    return <button onClick={this.handleClick}>Click Me!</button>;
   }
 }
 ```
@@ -90,23 +88,24 @@ You can also track events by importing `track()` and wrapping your stateless fun
 ```js
 import track from 'react-tracking';
 
-const FooPage = (props) => {
+const FooPage = props => {
   return (
-    <div onClick={() => {
+    <div
+      onClick={() => {
         props.tracking.trackEvent({ action: 'click' });
 
         // ... other stuff
       }}
     />
-  )
-}
+  );
+};
 
 export default track({
-  page: 'FooPage'
+  page: 'FooPage',
 })(FooPage);
 ```
 
-This is also how you would use this module without `@decorators`, although this is obviously awkward and the  decorator syntax is recommended.
+This is also how you would use this module without `@decorators`, although this is obviously awkward and the decorator syntax is recommended.
 
 ### Custom `options.dispatch()` for tracking data
 
@@ -118,7 +117,7 @@ For example, to push objects to `window.myCustomDataLayer[]` instead, you would 
 import React, { Component } from 'react';
 import track from 'react-tracking';
 
-@track({}, { dispatch: (data) => window.myCustomDataLayer.push(data) })
+@track({}, { dispatch: data => window.myCustomDataLayer.push(data) })
 export default class App extends Component {
   render() {
     return this.props.children;
@@ -166,7 +165,6 @@ class FooPage extends Component { ... }
 
 Will dispatch the following data (assuming no other tracking data in context from the rest of the app):
 
-
 ```
 {
   event: 'pageDataReady',
@@ -176,7 +174,7 @@ Will dispatch the following data (assuming no other tracking data in context fro
 
 ### Top level `options.process`
 
-When there's a need to implicitly dispatch an event with some data for *every* component, you can define an `options.process` function. This function should be declared once, at some top-level component. It will get called with each component's tracking data as the only argument. The returned object from this function will be merged with all the tracking context data and dispatched in `componentDidMount()`. If a falsy value is returned (`false`, `null`, `undefined`, ...), nothing will be dispatched.
+When there's a need to implicitly dispatch an event with some data for _every_ component, you can define an `options.process` function. This function should be declared once, at some top-level component. It will get called with each component's tracking data as the only argument. The returned object from this function will be merged with all the tracking context data and dispatched in `componentDidMount()`. If a falsy value is returned (`false`, `null`, `undefined`, ...), nothing will be dispatched.
 
 A common use case for this is to dispatch a `pageview` event for every component in the application that has a `page` property on its `trackingData`:
 
@@ -198,13 +196,13 @@ When `Page2` mounts, nothing will be dispatched.
 
 ### Tracking Asynchronous Methods
 
-Asynchronous methods (methods that return promises) can also be tracked when the method has resolved or rejects a promise. This is handled transparently, so simply decorating a asynchronous method the same way as a normal method will make the tracking call _after_ the promise is resolved or rejected.
+Asynchronous methods (methods that return promises) can also be tracked when the method has resolved or rejects a promise. This is handled transparently, so simply decorating an asynchronous method the same way as a normal method will make the tracking call _after_ the promise is resolved or rejected.
 
 ```js
 // ...
   @track()
   async handleEvent() {
-    await asyncCall(); // returns a promise
+    return await asyncCall(); // returns a promise
   }
 // ...
 ```
@@ -229,31 +227,25 @@ import track from 'react-tracking';
 
 // In this case, the "page" tracking data
 // is a function of one of its props (isNew)
-@track((props) => {
-  return { page: props.isNew ? 'new' : 'existing' }
+@track(props => {
+  return { page: props.isNew ? 'new' : 'existing' };
 })
 export default class FooButton extends React.Component {
-
   // In this case the tracking data depends on
   // some unknown (until runtime) value
   @track((props, state, [event]) => ({
     action: 'click',
-    label: event.currentTarget.title || event.currentTarget.textContent
+    label: event.currentTarget.title || event.currentTarget.textContent,
   }))
-  handleClick = (event) => {
+  handleClick = event => {
     if (this.props.onClick) {
       this.props.onClick(event);
     }
-  }
+  };
 
   render() {
-    return (
-      <button onClick={this.handleClick}>
-        {this.props.children}
-      </button>
-    );
+    return <button onClick={this.handleClick}>{this.props.children}</button>;
   }
-
 }
 ```
 
@@ -302,7 +294,7 @@ Further runtime data, such as the component's `props` and `state`, are available
 
 ```js
   @track((props, state) => ({
-    action: state.following ? "unfollow clicked" : "follow clicked" 
+    action: state.following ? "unfollow clicked" : "follow clicked"
     name: props.name
   }))
   handleFollow = () => {
@@ -324,18 +316,15 @@ import track from 'react-tracking';
   const randomId = Math.floor(Math.random() * 100);
 
   return {
-    page_view_id: randomId
-  }
+    page_view_id: randomId,
+  };
 })
 export default class AdComponent extends React.Component {
   render() {
     const { page_view_id } = this.props.tracking.getTrackingData();
 
-    return (
-      <Ad pageViewId={page_view_id} />
-    );
+    return <Ad pageViewId={page_view_id} />;
   }
-
 }
 ```
 
@@ -350,4 +339,3 @@ This library simply merges the tracking data objects together (as it flows throu
 ### TypeScript Support
 
 You can get the type definitions for React Tracking from DefinitelyTyped using `@types/react-tracking`. For an always up-to-date example of syntax, you should consult [the react-tracking type tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-tracking/test/react-tracking-with-types-tests.tsx).
-

--- a/src/__tests__/trackEventMethodDecorator.test.js
+++ b/src/__tests__/trackEventMethodDecorator.test.js
@@ -104,6 +104,47 @@ describe('trackEventMethodDecorator', () => {
     expect(spyTestEvent).toHaveBeenCalledWith(dummyArgument);
   });
 
+  it('properly passes through the correct arguments when trackingData is a function and the decorated method returns a promise', async () => {
+    const dummyData = {};
+    const trackingData = jest.fn(() => dummyData);
+    const trackEvent = jest.fn();
+    const dummyResolve = 'res';
+    const spyTestEvent = jest.fn(() => Promise.resolve(dummyResolve));
+    const dummyArgument = 'x';
+
+    class TestClass {
+      constructor() {
+        this.props = {
+          tracking: {
+            trackEvent,
+          },
+        };
+        this.state = {
+          myState: 'someState',
+        };
+      }
+
+      @trackEventMethodDecorator(trackingData) handleTestEvent = spyTestEvent;
+    }
+
+    const myTC = new TestClass();
+    await myTC.handleTestEvent(dummyArgument);
+
+    // Access the trackingData arguments
+    const trackingDataArguments = trackingData.mock.calls[0];
+
+    expect(trackingData).toHaveBeenCalledTimes(1);
+    expect(trackingDataArguments[0]).toEqual(myTC.props);
+    expect(trackingDataArguments[1]).toEqual(myTC.state);
+    // Here we have access to the raw `arguments` object, which is not an actual Array,
+    // so in order to compare, we convert the arguments to an array.
+    expect(Array.from(trackingDataArguments[2])).toEqual([dummyArgument]);
+    expect(trackingDataArguments[3]).toEqual([dummyResolve]);
+
+    expect(trackEvent).toHaveBeenCalledWith(dummyData);
+    expect(spyTestEvent).toHaveBeenCalledWith(dummyArgument);
+  });
+
   it('properly calls trackData when an async method has resolved', async () => {
     const dummyData = {};
     const trackingData = jest.fn(() => dummyData);
@@ -165,6 +206,9 @@ describe('trackEventMethodDecorator', () => {
       await myTC.handleTestEvent();
     } catch (error) {
       expect(trackEvent).toHaveBeenCalledWith(dummyData);
+      const trackingDataArguments = trackingData.mock.calls[0];
+      // the resulting error should be passed to the tracking data
+      expect(trackingDataArguments[3]).toEqual([null, error]);
       expect(error).toBeInstanceOf(Error);
     }
   });

--- a/src/__tests__/trackEventMethodDecorator.test.js
+++ b/src/__tests__/trackEventMethodDecorator.test.js
@@ -168,4 +168,35 @@ describe('trackEventMethodDecorator', () => {
       expect(error).toBeInstanceOf(Error);
     }
   });
+
+  it('calls the tracking method before the tracking decorator function', async () => {
+    const dummyData = {};
+    const trackingData = jest.fn(() => dummyData);
+    const trackEvent = jest.fn();
+    const spyTestEvent = jest.fn(() => Promise.resolve());
+
+    class TestClass {
+      constructor() {
+        this.props = {
+          tracking: {
+            trackEvent,
+          },
+        };
+      }
+
+      @trackEventMethodDecorator(trackingData) handleTestEvent = spyTestEvent;
+    }
+
+    const myTC = new TestClass();
+    myTC.handleTestEvent();
+
+    await myTC.handleTestEvent();
+
+    // all function calls should happen before all tracking calls
+    spyTestEvent.mock.invocationCallOrder.every(fnOrder =>
+      trackEvent.mock.invocationCallOrder.every(trackOrder =>
+        expect(fnOrder).toBeLessThan(trackOrder)
+      )
+    );
+  });
 });

--- a/src/__tests__/trackEventMethodDecorator.test.js
+++ b/src/__tests__/trackEventMethodDecorator.test.js
@@ -193,8 +193,8 @@ describe('trackEventMethodDecorator', () => {
     await myTC.handleTestEvent();
 
     // all function calls should happen before all tracking calls
-    spyTestEvent.mock.invocationCallOrder.every(fnOrder =>
-      trackEvent.mock.invocationCallOrder.every(trackOrder =>
+    spyTestEvent.mock.invocationCallOrder.forEach(fnOrder =>
+      trackEvent.mock.invocationCallOrder.forEach(trackOrder =>
         expect(fnOrder).toBeLessThan(trackOrder)
       )
     );

--- a/src/__tests__/trackEventMethodDecorator.test.js
+++ b/src/__tests__/trackEventMethodDecorator.test.js
@@ -136,15 +136,14 @@ describe('trackEventMethodDecorator', () => {
     expect(trackEvent).toHaveBeenCalledWith(dummyData);
   });
 
-  it('calls tracking function when the async function rejects', async () => {
+  it('calls tracking function when the async function throws and will rethrow the error', async () => {
     const dummyData = {};
     const trackingData = jest.fn(() => dummyData);
     const trackEvent = jest.fn();
-    let rejectTest;
     const spyTestEvent = jest.fn(
       () =>
-        new Promise((resolve, reject) => {
-          rejectTest = reject;
+        new Promise(() => {
+          throw new Error();
         })
     );
 
@@ -161,10 +160,12 @@ describe('trackEventMethodDecorator', () => {
     }
 
     const myTC = new TestClass();
-    myTC.handleTestEvent();
 
-    expect(trackEvent).not.toHaveBeenCalled();
-    await rejectTest();
-    expect(trackEvent).toHaveBeenCalledWith(dummyData);
+    try {
+      await myTC.handleTestEvent();
+    } catch (error) {
+      expect(trackEvent).toHaveBeenCalledWith(dummyData);
+      expect(error).toBeInstanceOf(Error);
+    }
   });
 });

--- a/src/__tests__/trackEventMethodDecorator.test.js
+++ b/src/__tests__/trackEventMethodDecorator.test.js
@@ -103,4 +103,68 @@ describe('trackEventMethodDecorator', () => {
     expect(trackEvent).toHaveBeenCalledWith(dummyData);
     expect(spyTestEvent).toHaveBeenCalledWith(dummyArgument);
   });
+
+  it('properly calls trackData when an async method has resolved', async () => {
+    const dummyData = {};
+    const trackingData = jest.fn(() => dummyData);
+    const trackEvent = jest.fn();
+    let resolveTest;
+    const spyTestEvent = jest.fn(
+      () =>
+        new Promise(resolve => {
+          resolveTest = resolve;
+        })
+    );
+
+    class TestClass {
+      constructor() {
+        this.props = {
+          tracking: {
+            trackEvent,
+          },
+        };
+      }
+
+      @trackEventMethodDecorator(trackingData) handleTestEvent = spyTestEvent;
+    }
+
+    const myTC = new TestClass();
+    myTC.handleTestEvent();
+
+    expect(trackEvent).not.toHaveBeenCalled();
+    await resolveTest();
+    expect(trackEvent).toHaveBeenCalledWith(dummyData);
+  });
+
+  it('calls tracking function when the async function rejects', async () => {
+    const dummyData = {};
+    const trackingData = jest.fn(() => dummyData);
+    const trackEvent = jest.fn();
+    let rejectTest;
+    const spyTestEvent = jest.fn(
+      () =>
+        new Promise((resolve, reject) => {
+          rejectTest = reject;
+        })
+    );
+
+    class TestClass {
+      constructor() {
+        this.props = {
+          tracking: {
+            trackEvent,
+          },
+        };
+      }
+
+      @trackEventMethodDecorator(trackingData) handleTestEvent = spyTestEvent;
+    }
+
+    const myTC = new TestClass();
+    myTC.handleTestEvent();
+
+    expect(trackEvent).not.toHaveBeenCalled();
+    await rejectTest();
+    expect(trackEvent).toHaveBeenCalledWith(dummyData);
+  });
 });

--- a/src/trackEventMethodDecorator.js
+++ b/src/trackEventMethodDecorator.js
@@ -1,10 +1,9 @@
-/* eslint-disable prefer-rest-params */
 import makeClassMemberDecorator from './makeClassMemberDecorator';
 
 export default function trackEventMethodDecorator(trackingData = {}) {
   return makeClassMemberDecorator(
     decoratedFn =>
-      function decorateClassMember() {
+      function decorateClassMember(...args) {
         const trackEvent = (...promiseArguments) => {
           if (
             this.props &&
@@ -13,18 +12,13 @@ export default function trackEventMethodDecorator(trackingData = {}) {
           ) {
             const thisTrackingData =
               typeof trackingData === 'function'
-                ? trackingData(
-                    this.props,
-                    this.state,
-                    arguments,
-                    promiseArguments
-                  )
+                ? trackingData(this.props, this.state, args, promiseArguments)
                 : trackingData;
             this.props.tracking.trackEvent(thisTrackingData);
           }
         };
 
-        const fn = Reflect.apply(decoratedFn, this, arguments);
+        const fn = Reflect.apply(decoratedFn, this, args);
         if (Promise && Promise.resolve(fn) === fn) {
           return fn.then(trackEvent.bind(this)).catch(error => {
             trackEvent(null, error);

--- a/src/trackEventMethodDecorator.js
+++ b/src/trackEventMethodDecorator.js
@@ -5,7 +5,7 @@ export default function trackEventMethodDecorator(trackingData = {}) {
   return makeClassMemberDecorator(
     decoratedFn =>
       function decorateClassMember() {
-        const trackEvent = () => {
+        const trackEvent = (...promiseArguments) => {
           if (
             this.props &&
             this.props.tracking &&
@@ -13,7 +13,12 @@ export default function trackEventMethodDecorator(trackingData = {}) {
           ) {
             const thisTrackingData =
               typeof trackingData === 'function'
-                ? trackingData(this.props, this.state, arguments)
+                ? trackingData(
+                    this.props,
+                    this.state,
+                    arguments,
+                    promiseArguments
+                  )
                 : trackingData;
             this.props.tracking.trackEvent(thisTrackingData);
           }
@@ -22,7 +27,7 @@ export default function trackEventMethodDecorator(trackingData = {}) {
         const fn = Reflect.apply(decoratedFn, this, arguments);
         if (Promise && Promise.resolve(fn) === fn) {
           return fn.then(trackEvent.bind(this)).catch(error => {
-            trackEvent();
+            trackEvent(null, error);
             throw error;
           });
         }

--- a/src/trackEventMethodDecorator.js
+++ b/src/trackEventMethodDecorator.js
@@ -1,9 +1,10 @@
+/* eslint-disable prefer-rest-params */
 import makeClassMemberDecorator from './makeClassMemberDecorator';
 
 export default function trackEventMethodDecorator(trackingData = {}) {
   return makeClassMemberDecorator(
     decoratedFn =>
-      function decorateClassMember(...args) {
+      function decorateClassMember() {
         const trackEvent = (...promiseArguments) => {
           if (
             this.props &&
@@ -12,13 +13,18 @@ export default function trackEventMethodDecorator(trackingData = {}) {
           ) {
             const thisTrackingData =
               typeof trackingData === 'function'
-                ? trackingData(this.props, this.state, args, promiseArguments)
+                ? trackingData(
+                    this.props,
+                    this.state,
+                    arguments,
+                    promiseArguments
+                  )
                 : trackingData;
             this.props.tracking.trackEvent(thisTrackingData);
           }
         };
 
-        const fn = Reflect.apply(decoratedFn, this, args);
+        const fn = Reflect.apply(decoratedFn, this, arguments);
         if (Promise && Promise.resolve(fn) === fn) {
           return fn.then(trackEvent.bind(this)).catch(error => {
             trackEvent(null, error);

--- a/src/trackEventMethodDecorator.js
+++ b/src/trackEventMethodDecorator.js
@@ -5,19 +5,26 @@ export default function trackEventMethodDecorator(trackingData = {}) {
   return makeClassMemberDecorator(
     decoratedFn =>
       function decorateClassMember() {
-        if (
-          this.props &&
-          this.props.tracking &&
-          typeof this.props.tracking.trackEvent === 'function'
-        ) {
-          const thisTrackingData =
-            typeof trackingData === 'function'
-              ? trackingData(this.props, this.state, arguments)
-              : trackingData;
-          this.props.tracking.trackEvent(thisTrackingData);
-        }
+        const trackEvent = () => {
+          if (
+            this.props &&
+            this.props.tracking &&
+            typeof this.props.tracking.trackEvent === 'function'
+          ) {
+            const thisTrackingData =
+              typeof trackingData === 'function'
+                ? trackingData(this.props, this.state, arguments)
+                : trackingData;
+            this.props.tracking.trackEvent(thisTrackingData);
+          }
+        };
 
-        return Reflect.apply(decoratedFn, this, arguments);
+        const fn = Reflect.apply(decoratedFn, this, arguments);
+        if (Promise && Promise.resolve(fn) === fn) {
+          return fn.then(trackEvent.bind(this), trackEvent.bind(this));
+        }
+        trackEvent();
+        return fn;
       }
   );
 }

--- a/src/trackEventMethodDecorator.js
+++ b/src/trackEventMethodDecorator.js
@@ -21,7 +21,10 @@ export default function trackEventMethodDecorator(trackingData = {}) {
 
         const fn = Reflect.apply(decoratedFn, this, arguments);
         if (Promise && Promise.resolve(fn) === fn) {
-          return fn.then(trackEvent.bind(this), trackEvent.bind(this));
+          return fn.then(trackEvent.bind(this)).catch(error => {
+            trackEvent();
+            throw error;
+          });
         }
         trackEvent();
         return fn;


### PR DESCRIPTION
This introduces the ability to use `@track` on asynchronous methods and have the track functionality run *after* the method has resolved:

```js
{
...
    @track()
    async fireEvent() {
        await eventDispatch();
    }
}
```

It doesn't change the ability to track non-async methods.

Because the tracked method needs to be run before it can be identified as an asynchronous method (it returns a Promise), this change alters the flow of when the function and tracking are called. In all cases, the function will run *and then* the tracking will be called.

Since this deviates from the original order of operations, I can see how this may introduce unwanted effects. Alternatively, I can see a new `@trackAsync` decorator that could be used for this. I do prefer transparent handling of this kind of thing, and not having two different decorators depending on usage.

I realize that there are also alternate ways to address the above (as talked about here: https://github.com/NYTimes/react-tracking/issues/42), but I think adding additional methods simply for promise chain handling or explicitly calling `trackEvent` reduces some of the elegance and simplicity of this approach.