### PR TITLE
Guard against pushing empty events

### DIFF
--- a/src/__tests__/dispatchTrackingEvent.test.js
+++ b/src/__tests__/dispatchTrackingEvent.test.js
@@ -28,4 +28,14 @@ describe('dispatchTrackingEvent', () => {
     dispatchTrackingEvent(testEventData);
     expect(window.dataLayer).toEqual([testEventData, testEventData]);
   });
+
+  it('will not push to window.dataLayer[] if the event data is empty', () => {
+    expect(window.dataLayer).not.toBeDefined();
+
+    dispatchTrackingEvent(testEventData);
+    expect(window.dataLayer).toEqual([testEventData]);
+
+    dispatchTrackingEvent({});
+    expect(window.dataLayer).toEqual([testEventData]);
+  });
 });

--- a/src/dispatchTrackingEvent.js
+++ b/src/dispatchTrackingEvent.js
@@ -1,3 +1,5 @@
 export default function dispatchTrackingEvent(data) {
-  (window.dataLayer = window.dataLayer || []).push(data);
+  if (Object.keys(data).length > 0) {
+    (window.dataLayer = window.dataLayer || []).push(data);
+  }
 }


### PR DESCRIPTION
If you have multiple mount points in your app, or if you only use `react-tracking` in subtrees of your React app, you may encounter a situation where you see empty tracking objects pushed to your data store. That's... not terribly useful.

This change prevents empty objects from being pushed to `window.dataLayer`.