### PR TITLE
Expose return value of dispatch call via trackEvent

### DIFF
--- a/src/withTrackingComponentDecorator.js
+++ b/src/withTrackingComponentDecorator.js
@@ -96,12 +96,11 @@ export default function withTrackingComponentDecorator(
         return (tracking && tracking.dispatch) || dispatch;
       }
 
-      trackEvent = data => {
+      trackEvent = data =>
         this.getTrackingDispatcher()(
           // deep-merge tracking data from context and tracking data passed in here
           merge(this.trackingData || {}, data || {})
         );
-      };
 
       computeTrackingData(props, context) {
         this.ownTrackingData =


### PR DESCRIPTION
This allows us to receive the result of the dispatch function in trackEvent calls.  

Main use case for this is waiting to execute code until the event has been successfully tracked.  Our tracking method inside of dispatch() returns a promise that resolves when the event has been successfully tracked.

We can use this to delay execution of events (for example exiting link clicks on critical events) until the event has tracked.