### PR TITLE
Don't invoke trackEvent when tracking data is null or undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ When tracking asynchronous methods, you can also receive the resolved or rejecte
 // ...
 ```
 
+If the function returns `null` or `undefined` then no data will be tracked.
+
 ### Accessing data stored in the component's `props` and `state`
 
 Further runtime data, such as the component's `props` and `state`, are available as follows:

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ When tracking asynchronous methods, you can also receive the resolved or rejecte
 // ...
 ```
 
-If the function returns `null` or `undefined` then no data will be tracked.
+If the function returns a falsy value (e.g. `false`, `null` or `undefined`) then the tracking call will not be made.
 
 ### Accessing data stored in the component's `props` and `state`
 

--- a/src/__tests__/trackEventMethodDecorator.test.js
+++ b/src/__tests__/trackEventMethodDecorator.test.js
@@ -148,6 +148,34 @@ describe('trackEventMethodDecorator', () => {
     expect(spyTestEvent).toHaveBeenCalledWith(dummyArgument);
   });
 
+  [null, undefined].forEach(value => {
+    it(`does not call trackEvent if the data is ${value}`, () => {
+      const trackingData = jest.fn(() => value);
+      const trackEvent = jest.fn();
+      const spyTestEvent = jest.fn();
+
+      class TestClass {
+        constructor() {
+          this.props = {
+            tracking: {
+              trackEvent,
+            },
+          };
+        }
+
+        @trackEventMethodDecorator(trackingData)
+        handleTestEvent = spyTestEvent;
+      }
+
+      const myTC = new TestClass();
+      myTC.handleTestEvent('x');
+
+      expect(trackingData).toHaveBeenCalledTimes(1);
+      expect(trackEvent).not.toHaveBeenCalled();
+      expect(spyTestEvent).toHaveBeenCalledWith('x');
+    });
+  });
+
   it('properly calls trackData when an async method has resolved', async () => {
     const dummyData = {};
     const trackingData = jest.fn(() => dummyData);

--- a/src/trackEventMethodDecorator.js
+++ b/src/trackEventMethodDecorator.js
@@ -14,7 +14,9 @@ export default function trackEventMethodDecorator(trackingData = {}) {
               typeof trackingData === 'function'
                 ? trackingData(this.props, this.state, args, promiseArguments)
                 : trackingData;
-            this.props.tracking.trackEvent(thisTrackingData);
+            if (thisTrackingData) {
+              this.props.tracking.trackEvent(thisTrackingData);
+            }
           }
         };
 


### PR DESCRIPTION
This change allows us to conditionally track events depending on the return value of the function passed into `@track`. If the function returns `null` or `undefined` then `trackEvent` will not be invoked.

We've patched this in our own version of `react-tracking` in order to only track when a user _unchecks_ a box. Example code is below and can be found [here](https://github.com/artsy/reaction/pull/1459/files#diff-ec0ceeeb68c615892b6b5a053119b0edR143).

```
  @track((props, state, args) => {
    const willInputBillingAddress = !args[0]
    if (willInputBillingAddress) {
      return {
        action_type: Schema.ActionType.Click,
        subject: Schema.Subject.BNMOUseShippingAddress,
        flow: "buy now",
        type: "checkbox",
      }
    }
  })
  handleChangeHideBillingAddress(hideBillingAddress: boolean) {
    ...
  }
```