### PR TITLE
Add mock tracking provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,24 @@ Note that there are no restrictions on the objects that are passed in to the dec
 
 This library simply merges the tracking data objects together (as it flows through your app's React component hierarchy) into a single object that's ultimately sent to the tracking library.
 
+### Testing
+
+To mock your tracking whilst testing, this library exports `withMockTrackingProvider`. This uses a simplifed API which allows you to provide a mock dispatch to your test subject so that it can be easily asserted on.
+
+```js
+import { withMockTrackingProvider } from 'react-tracking';
+import ComponentUnderTest from './ComponentUnderTest';
+
+const mockDispatch = jest.fn();
+const TrackedComponent = withMockTrackingProvider(mockDispatch)(ComponentUnderTest);
+
+// render TrackedComponent and fire tracking
+
+it('calls tracking dispatch method with tracking data', () => {
+  expect(mockDispatch).toHaveBeenCalledWith( /* expected data object */ );
+});
+```
+
 ### TypeScript Support
 
 You can get the type definitions for React Tracking from DefinitelyTyped using `@types/react-tracking`. For an always up-to-date example of syntax, you should consult [the react-tracking type tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-tracking/test/react-tracking-with-types-tests.tsx).

--- a/src/__tests__/withMockTrackingProvider.test.js
+++ b/src/__tests__/withMockTrackingProvider.test.js
@@ -1,0 +1,29 @@
+const withMTPMockWrapped = jest.fn();
+const withMTPMockDispatch = jest.fn(() => withMTPMockWrapped);
+
+jest.setMock('../trackingHoC', withMTPMockDispatch);
+
+describe('mock tracking provider', () => {
+  // eslint-disable-next-line global-require
+  const withMockTrackingProvider = require('../withMockTrackingProvider')
+    .default;
+
+  const ComponentToWrap = () => {};
+
+  const stubDispatch = () => {};
+  const expectedTrackingArguments = [{}, { dispatch: stubDispatch }];
+
+  beforeEach(() => {
+    withMockTrackingProvider(stubDispatch)(ComponentToWrap);
+  });
+
+  it('calls trackingHoC with the correct arguments', () => {
+    expect(withMTPMockDispatch).toHaveBeenCalledWith(
+      ...expectedTrackingArguments
+    );
+  });
+
+  it('calls the returned function with the wrapped component', () => {
+    expect(withMTPMockWrapped).toHaveBeenCalledWith(ComponentToWrap);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,11 @@
 export {
+  default as withMockTrackingProvider,
+} from './withMockTrackingProvider';
+export {
   default as withTracking,
   TrackingContextType,
 } from './withTrackingComponentDecorator';
 export { default as trackEvent } from './trackEventMethodDecorator';
 export { default as TrackingPropType } from './TrackingPropType';
-export { default as withMockTrackingProvider } from './withMockTrackingProvider';
+
 export { default } from './trackingHoC';

--- a/src/index.js
+++ b/src/index.js
@@ -4,4 +4,5 @@ export {
 } from './withTrackingComponentDecorator';
 export { default as trackEvent } from './trackEventMethodDecorator';
 export { default as TrackingPropType } from './TrackingPropType';
+export { default as withMockTrackingProvider } from './withMockTrackingProvider';
 export { default } from './trackingHoC';

--- a/src/withMockTrackingProvider.js
+++ b/src/withMockTrackingProvider.js
@@ -1,0 +1,6 @@
+import trackingHoC from './trackingHoC';
+
+const withMockTrackingProvider = dispatch => WrappedComponent =>
+  trackingHoC({}, { dispatch })(WrappedComponent);
+
+export default withMockTrackingProvider;


### PR DESCRIPTION
Exports `withMockTrackingProvider`. A simplified API around react-tracking's `trackingHoC` method for testing tracked components.

I wasn't sure how best to test my components with react-tracking and after reading an open issue I realised I wasn't the only one.

By providing this test helper we can document in the README a simple way to test functional or class-based components without having to mock the entire library (react-tracking).

This may seem unnecessary as the `track` method could be imported into tests and used in the same way but having a separate provider gives us:
 • A simplified API that only exposes the dispatch option
 • Clearer naming, making tests easier to understand
 • It encourages better testing, no need to mock the entire library, and this can be documented.

I haven’t tested this locally yet. If initial feedback is good I’ll make sure it works.

Great work on the library everyone!
Let me know your thoughts.