### PR TITLE
new context api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tracking",
-  "version": "5.7.0",
+  "version": "6.0.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "build:watch": "npm run build -- --watch",
     "test": "jest",
     "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
     "lint": "eslint ./src"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tracking",
-  "version": "5.7.0",
+  "version": "6.0.0-0",
   "description": "Declarative tracking for React apps.",
   "author": "The New York Times",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "core-js": "2.x",
-    "react": "^15.0.0 || ^16.0.0",
+    "react": "^16.3",
     "prop-types": "^15.x"
   },
   "devDependencies": {

--- a/src/__tests__/e2e.test.js
+++ b/src/__tests__/e2e.test.js
@@ -526,7 +526,7 @@ describe('e2e', () => {
 
     expect(global.console.error).toHaveBeenCalledTimes(1);
     expect(global.console.error).toHaveBeenCalledWith(
-      '[react-tracking] options.process should be used once on top level component'
+      '[react-tracking] options.process should be defined once on a top-level component'
     );
   });
 

--- a/src/__tests__/e2e.test.js
+++ b/src/__tests__/e2e.test.js
@@ -18,6 +18,35 @@ describe('e2e', () => {
     jest.clearAllMocks();
   });
 
+  it('defaults moslty everything', () => {
+    @track(null, { process: () => null })
+    class TestDefaults extends React.Component {
+      render() {
+        return this.props.children;
+      }
+    }
+
+    @track()
+    class Child extends React.Component {
+      componentDidMount() {
+        this.props.tracking.trackEvent({ test: true });
+      }
+
+      render() {
+        return 'hi';
+      }
+    }
+
+    mount(
+      <TestDefaults>
+        <Child />
+      </TestDefaults>
+    );
+
+    expect(dispatchTrackingEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchTrackingEvent).toHaveBeenCalledWith({ test: true });
+  });
+
   it('defaults to dispatchTrackingEvent when no dispatch function passed in to options', () => {
     const testPageData = { page: 'TestPage' };
 
@@ -429,6 +458,40 @@ describe('e2e', () => {
       ...testDataContext,
       ...testState,
     });
+  });
+
+  it('can read tracking data from props.tracking.getTrackingData()', () => {
+    const mockReader = jest.fn();
+
+    @track(({ onProps }) => ({ onProps, ...testDataContext }))
+    class TestOptions extends React.Component {
+      render() {
+        return this.props.children;
+      }
+    }
+
+    @track({ child: true })
+    class TestChild extends React.Component {
+      render() {
+        mockReader(this.props.tracking.getTrackingData());
+        return 'hi';
+      }
+    }
+
+    mount(
+      <TestOptions onProps="yes">
+        <TestChild />
+      </TestOptions>
+    );
+
+    expect(mockReader).toHaveBeenCalledTimes(1);
+    expect(mockReader).toHaveBeenCalledWith({
+      child: true,
+      onProps: 'yes',
+      ...testDataContext,
+    });
+
+    expect(dispatchTrackingEvent).not.toHaveBeenCalled();
   });
 
   it('logs a console error when there is already a process defined on context', () => {

--- a/src/__tests__/withTrackingComponentDecorator.test.js
+++ b/src/__tests__/withTrackingComponentDecorator.test.js
@@ -34,12 +34,11 @@ describe('withTrackingComponentDecorator', () => {
 
     it('defines the expected static properties', () => {
       expect(TestComponent.displayName).toBe('WithTracking(TestComponent)');
-      expect(TestComponent.contextTypes.tracking).toBeDefined();
-      expect(TestComponent.childContextTypes.tracking).toBeDefined();
+      expect(TestComponent.contextType).toBeDefined();
     });
 
-    it('calls trackingContext() in getChildContext', () => {
-      expect(myTC.getChildContext().tracking.data).toEqual({});
+    it('calls trackingContext() in getContextForProvider', () => {
+      expect(myTC.getContextForProvider().tracking.data).toEqual({});
       expect(trackingContext).toHaveBeenCalledTimes(1);
     });
 
@@ -79,8 +78,8 @@ describe('withTrackingComponentDecorator', () => {
 
     // We'll only test what differs from the functional trackingContext variation
 
-    it('returns the proper object in getChildContext', () => {
-      expect(myTC.getChildContext().tracking).toEqual({
+    it('returns the proper object in getContextForProvider', () => {
+      expect(myTC.getContextForProvider().tracking).toEqual({
         data: trackingContext,
         dispatch: mockDispatchTrackingEvent,
       });
@@ -186,7 +185,7 @@ describe('withTrackingComponentDecorator', () => {
       static displayName = 'TestComponent';
     }
 
-    const component = shallow(<TestComponent />);
+    const component = shallow(<TestComponent />).children();
 
     beforeEach(() => {
       mockDispatchTrackingEvent.mockClear();

--- a/src/withTrackingComponentDecorator.js
+++ b/src/withTrackingComponentDecorator.js
@@ -32,7 +32,7 @@ export default function withTrackingComponentDecorator(
         if (context.tracking && context.tracking.process && process) {
           // eslint-disable-next-line
           console.error(
-            '[react-tracking] options.process should be used once on top level component'
+            '[react-tracking] options.process should be defined once on a top-level component'
           );
         }
 
@@ -77,10 +77,7 @@ export default function withTrackingComponentDecorator(
         const { tracking } = this.context;
         return {
           tracking: {
-            data: merge(
-              this.contextTrackingData || {},
-              this.ownTrackingData || {}
-            ),
+            data: this.trackingData,
             dispatch: this.getTrackingDispatcher(),
             process: (tracking && tracking.process) || process,
           },
@@ -110,11 +107,13 @@ export default function withTrackingComponentDecorator(
           this.contextTrackingData || {},
           this.ownTrackingData || {}
         );
+
+        this.contextForProvider = this.getContextForProvider();
       }
 
       render() {
         return (
-          <ReactTrackingContext.Provider value={this.getContextForProvider()}>
+          <ReactTrackingContext.Provider value={this.contextForProvider}>
             <DecoratedComponent {...this.props} tracking={this.tracking} />
           </ReactTrackingContext.Provider>
         );


### PR DESCRIPTION
Updates to use new Context API, [React.createContext()](https://reactjs.org/docs/context.html)

After this is published, minimum React will be 16.3

Closes #67 