### PR TITLE
Export ReactTrackingContext

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 export {
   default as withTracking,
+  ReactTrackingContext,
   TrackingContextType,
 } from './withTrackingComponentDecorator';
 export { default as trackEvent } from './trackEventMethodDecorator';


### PR DESCRIPTION
We're currently exploring some different hooks patterns involving `react-tracking` but noticed that `ReactTrackingContext` isn't exported from the main index, requiring us to dig in like so: 
```js
import { ReactTrackingContext } from "react-tracking/build/withTrackingComponentDecorator"
```
This moves things up to the main `index` file. 