### PR TITLE
Add new `useTracking` React hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,24 @@ export default track({
 })(FooPage);
 ```
 
+### Usage with React Hooks
+
+Following the example above, once a component is wrapped with `track` we can access a `tracking` object via the `useTracking` hook from anywhere in the sub-tree:
+
+```js
+import { useTracking } from 'react-tracking'
+
+const SomeChild = props => {
+  const tracking = useTracking()
+
+  <div
+    onClick={() => {
+      tracking.trackEvent({ action: 'click' });
+    }}
+  />
+}
+```
+
 This is also how you would use this module without `@decorators`, although this is obviously awkward and the decorator syntax is recommended.
 
 ### Custom `options.dispatch()` for tracking data

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "core-js": "3.x",
-    "react": "^16.3",
+    "react": "^16.8",
     "prop-types": "^15.x"
   },
   "devDependencies": {

--- a/src/__tests__/useTracking.test.js
+++ b/src/__tests__/useTracking.test.js
@@ -1,0 +1,55 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import track from '../withTrackingComponentDecorator';
+import useTracking from '../useTracking';
+
+describe('useTracking', () => {
+  it('throws error if tracking context not present', () => {
+    const ThrowMissingContext = () => {
+      useTracking();
+      return <div>hi</div>;
+    };
+    try {
+      renderToString(<ThrowMissingContext />);
+    } catch (error) {
+      expect(error.message).toContain(
+        'Attempting to call `useTracking` without a ReactTrackingContext present'
+      );
+    }
+  });
+
+  it('dispatches tracking events from a useTracking hook tracking object', () => {
+    const outerTrackingData = {
+      page: 'Page',
+    };
+
+    const dispatch = jest.fn();
+
+    const App = track(outerTrackingData, { dispatch })(() => {
+      const tracking = useTracking();
+
+      expect(tracking.getTrackingData()).toEqual({
+        page: 'Page',
+      });
+
+      return (
+        <button
+          type="button"
+          onClick={() =>
+            tracking.trackEvent({
+              event: 'buttonClick',
+            })
+          }
+        />
+      );
+    });
+
+    const wrapper = mount(<App />);
+    wrapper.simulate('click');
+    expect(dispatch).toHaveBeenCalledWith({
+      ...outerTrackingData,
+      event: 'buttonClick',
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -5,4 +5,5 @@ export {
 } from './withTrackingComponentDecorator';
 export { default as trackEvent } from './trackEventMethodDecorator';
 export { default as TrackingPropType } from './TrackingPropType';
+export { default as useTracking } from './useTracking';
 export { default } from './trackingHoC';

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 export {
   default as withTracking,
+  ReactTrackingContext,
   TrackingContextType,
 } from './withTrackingComponentDecorator';
 export { default as trackEvent } from './trackEventMethodDecorator';

--- a/src/useTracking.js
+++ b/src/useTracking.js
@@ -1,0 +1,26 @@
+import merge from 'deepmerge';
+import { useContext, useMemo } from 'react';
+import { ReactTrackingContext } from './withTrackingComponentDecorator';
+
+export default function useTracking() {
+  const trackingContext = useContext(ReactTrackingContext);
+
+  if (!(trackingContext && trackingContext.tracking)) {
+    throw new Error(
+      'Attempting to call `useTracking` ' +
+        'without a ReactTrackingContext present. Did you forget to wrap the top of ' +
+        'your component tree with `track`?'
+    );
+  }
+
+  return useMemo(
+    () => ({
+      getTrackingData: () => trackingContext.tracking.data,
+      trackEvent: data =>
+        trackingContext.tracking.dispatch(
+          merge(trackingContext.tracking.data, data)
+        ),
+    }),
+    [trackingContext.tracking.data]
+  );
+}


### PR DESCRIPTION
Closes https://github.com/nytimes/react-tracking/issues/120

#### Note 
> This is an internal pattern that we're currently rolling out to devs on our team and have yet to use extensively. Wanted to open up a PR for feedback and other suggestions.

#### Overview  

This PR adds a new `useTracking` hook now that https://github.com/nytimes/react-tracking/pull/118 has been implemented. 

#### Usage

```jsx
// App.js 

import { track } from 'react-tracking'
import { Child } from './Child'

// Inject a tracking context into the tree
const App = track({
 foo: 'bar'
})(props => {
  return <Child />
})
```
And then the parent and children can pull it out via `useTracking`
```jsx
import { useTracking } from 'react-tracking'

export const Child = () => {
  const tracking = useTracking()  

  return <div onClick={() => tracking.trackEvent(...)}>
}
```

Since Hooks are only supported in React 16.8+, this requires a major version bump as it's a breaking change. Which leads to the question: should decorators be deprecated inside of `react-tracking`? The decorator proposal is still Stage II, and doesn't seem to be going anywhere. 