### PR TITLE
feat(withTrackingComponentDecorator): rewrite context behavior to improve performance

### DIFF
--- a/src/__tests__/e2e.test.js
+++ b/src/__tests__/e2e.test.js
@@ -605,18 +605,18 @@ describe('e2e', () => {
     });
 
     const App = track()(() => {
-      const [props, setProps] = React.useState({});
+      const [state, setState] = React.useState({});
 
       return (
         <div className="App">
           <h1>Extra renders of InnerComponent caused by new context API</h1>
           <button
-            onClick={() => setProps({ count: props.count + 1 })}
+            onClick={() => setState({ count: state.count + 1 })}
             type="button"
           >
             Update Props
           </button>
-          <OuterComponent trackedProp={props}>
+          <OuterComponent trackedProp={state}>
             <MiddleComponent middleProp={1}>
               <InnerComponent innerProps="a" />
             </MiddleComponent>

--- a/src/__tests__/e2e.test.js
+++ b/src/__tests__/e2e.test.js
@@ -125,9 +125,11 @@ describe('e2e', () => {
       }
     }
 
-    const TestData2 = track(testData2, { dispatchOnMount: true })(() => (
-      <div />
-    ));
+    const TestData3 = track({ key: { x: 3, y: 3 } }, { dispatchOnMount: true })(
+      () => <div />
+    );
+
+    const TestData2 = track(testData2)(() => <TestData3 />);
 
     mount(
       <TestData1>
@@ -137,7 +139,7 @@ describe('e2e', () => {
 
     expect(dispatchTrackingEvent).toHaveBeenCalledWith({
       page: 'TestDeepMerge',
-      key: { x: 2, y: 1, z: 2 },
+      key: { x: 3, y: 3, z: 2 },
     });
   });
 
@@ -585,6 +587,51 @@ describe('e2e', () => {
     });
   });
 
+  it('does not cause unnecessary updates due to context changes', () => {
+    let innerRenderCount = 0;
+
+    const OuterComponent = track()(props => props.children);
+
+    const MiddleComponent = track()(
+      React.memo(
+        props => props.children,
+        (props, prevProps) => props.middleProp === prevProps.middleProp
+      )
+    );
+
+    const InnerComponent = track()(() => {
+      innerRenderCount += 1;
+      return null;
+    });
+
+    const App = track()(() => {
+      const [props, setProps] = React.useState({});
+
+      return (
+        <div className="App">
+          <h1>Extra renders of InnerComponent caused by new context API</h1>
+          <button
+            onClick={() => setProps({ count: props.count + 1 })}
+            type="button"
+          >
+            Update Props
+          </button>
+          <OuterComponent trackedProp={props}>
+            <MiddleComponent middleProp={1}>
+              <InnerComponent innerProps="a" />
+            </MiddleComponent>
+          </OuterComponent>
+        </div>
+      );
+    });
+
+    const wrapper = mount(<App />);
+
+    wrapper.find('button').simulate('click');
+
+    expect(innerRenderCount).toEqual(1);
+  });
+
   it('root context items are accessible to children', () => {
     const App = track()(() => {
       return <Child />;
@@ -593,8 +640,8 @@ describe('e2e', () => {
     const Child = () => {
       const trackingContext = useContext(ReactTrackingContext);
       expect(Object.keys(trackingContext.tracking)).toEqual([
-        'data',
         'dispatch',
+        'getTrackingData',
         'process',
       ]);
       return <div />;

--- a/src/__tests__/withTrackingComponentDecorator.test.js
+++ b/src/__tests__/withTrackingComponentDecorator.test.js
@@ -38,7 +38,9 @@ describe('withTrackingComponentDecorator', () => {
     });
 
     it('calls trackingContext() in getContextForProvider', () => {
-      expect(myTC.getContextForProvider().tracking.data).toEqual({});
+      expect(myTC.contextValueForProvider.tracking.getTrackingData()).toEqual(
+        {}
+      );
       expect(trackingContext).toHaveBeenCalledTimes(1);
     });
 
@@ -79,10 +81,11 @@ describe('withTrackingComponentDecorator', () => {
     // We'll only test what differs from the functional trackingContext variation
 
     it('returns the proper object in getContextForProvider', () => {
-      expect(myTC.getContextForProvider().tracking).toEqual({
-        data: trackingContext,
-        dispatch: mockDispatchTrackingEvent,
-      });
+      expect(Object.keys(myTC.contextValueForProvider.tracking)).toEqual([
+        'dispatch',
+        'getTrackingData',
+        'process',
+      ]);
     });
 
     it('dispatches event in componentDidMount', () => {

--- a/src/useTracking.js
+++ b/src/useTracking.js
@@ -14,8 +14,8 @@ export default function useTracking() {
 
   return useMemo(
     () => ({
-      getTrackingData: () => trackingContext.tracking.getTrackingData(),
-      trackEvent: data => trackingContext.tracking.dispatch(data),
+      getTrackingData: trackingContext.tracking.getTrackingData,
+      trackEvent: trackingContext.tracking.dispatch,
     }),
     [
       trackingContext.tracking.getTrackingData,

--- a/src/useTracking.js
+++ b/src/useTracking.js
@@ -1,4 +1,3 @@
-import merge from 'deepmerge';
 import { useContext, useMemo } from 'react';
 import { ReactTrackingContext } from './withTrackingComponentDecorator';
 
@@ -15,12 +14,12 @@ export default function useTracking() {
 
   return useMemo(
     () => ({
-      getTrackingData: () => trackingContext.tracking.data,
-      trackEvent: data =>
-        trackingContext.tracking.dispatch(
-          merge(trackingContext.tracking.data, data)
-        ),
+      getTrackingData: () => trackingContext.tracking.getTrackingData(),
+      trackEvent: data => trackingContext.tracking.dispatch(data),
     }),
-    [trackingContext.tracking.data]
+    [
+      trackingContext.tracking.getTrackingData,
+      trackingContext.tracking.dispatch,
+    ]
   );
 }

--- a/src/withTrackingComponentDecorator.js
+++ b/src/withTrackingComponentDecorator.js
@@ -29,23 +29,29 @@ export default function withTrackingComponentDecorator(
       constructor(props, context) {
         super(props, context);
 
-        if (context.tracking && context.tracking.process && process) {
+        if (this.getProcessFn() && process) {
           // eslint-disable-next-line
           console.error(
             '[react-tracking] options.process should be defined once on a top-level component'
           );
         }
 
-        this.computeTrackingData(props, context);
         this.tracking = {
           trackEvent: this.trackEvent,
-          getTrackingData: () => this.trackingData,
+          getTrackingData: this.getTrackingData(),
+        };
+
+        this.contextValueForProvider = {
+          tracking: {
+            dispatch: this.getTrackingDispatcher(),
+            getTrackingData: this.getTrackingData(),
+            process: this.getProcessFn() || process,
+          },
         };
       }
 
       componentDidMount() {
-        const { tracking } = this.context;
-        const contextProcess = tracking && tracking.process;
+        const contextProcess = this.getProcessFn();
 
         if (
           typeof contextProcess === 'function' &&
@@ -53,67 +59,60 @@ export default function withTrackingComponentDecorator(
         ) {
           this.trackEvent(
             merge(
-              contextProcess(this.ownTrackingData) || {},
-              dispatchOnMount(this.trackingData) || {}
+              contextProcess(this.getOwnTrackingData()) || {},
+              dispatchOnMount(this.tracking.getTrackingData()) || {}
             )
           );
         } else if (typeof contextProcess === 'function') {
-          const processed = contextProcess(this.ownTrackingData);
+          const processed = contextProcess(this.getOwnTrackingData());
           if (processed || dispatchOnMount === true) {
             this.trackEvent(processed);
           }
         } else if (typeof dispatchOnMount === 'function') {
-          this.trackEvent(dispatchOnMount(this.trackingData));
+          this.trackEvent(dispatchOnMount(this.tracking.getTrackingData()));
         } else if (dispatchOnMount === true) {
           this.trackEvent();
         }
       }
 
-      componentWillReceiveProps(nextProps, nextContext) {
-        this.computeTrackingData(nextProps, nextContext);
-      }
-
-      getContextForProvider() {
+      getProcessFn = () => {
         const { tracking } = this.context;
-        return {
-          tracking: {
-            data: this.trackingData,
-            dispatch: this.getTrackingDispatcher(),
-            process: (tracking && tracking.process) || process,
-          },
-        };
-      }
-
-      getTrackingDispatcher() {
-        const { tracking } = this.context;
-        return (tracking && tracking.dispatch) || dispatch;
-      }
-
-      trackEvent = data => {
-        this.getTrackingDispatcher()(
-          // deep-merge tracking data from context and tracking data passed in here
-          merge(this.trackingData || {}, data || {})
-        );
+        return tracking && tracking.process;
       };
 
-      computeTrackingData(props, context) {
-        this.ownTrackingData =
+      getOwnTrackingData = () => {
+        const ownTrackingData =
           typeof trackingData === 'function'
-            ? trackingData(props)
+            ? trackingData(this.props)
             : trackingData;
-        this.contextTrackingData =
-          (context.tracking && context.tracking.data) || {};
-        this.trackingData = merge(
-          this.contextTrackingData || {},
-          this.ownTrackingData || {}
-        );
+        return ownTrackingData || {};
+      };
 
-        this.contextForProvider = this.getContextForProvider();
-      }
+      getTrackingData = () => {
+        const { tracking } = this.context;
+        const contextGetTrackingData =
+          (tracking && tracking.getTrackingData) || this.getOwnTrackingData;
+
+        return () =>
+          contextGetTrackingData === this.getOwnTrackingData
+            ? this.getOwnTrackingData()
+            : merge(contextGetTrackingData(), this.getOwnTrackingData());
+      };
+
+      getTrackingDispatcher = () => {
+        const { tracking } = this.context;
+        const contextDispatch = (tracking && tracking.dispatch) || dispatch;
+        return data =>
+          contextDispatch(merge(this.getOwnTrackingData(), data || {}));
+      };
+
+      trackEvent = (data = {}) => {
+        this.contextValueForProvider.tracking.dispatch(data);
+      };
 
       render() {
         return (
-          <ReactTrackingContext.Provider value={this.contextForProvider}>
+          <ReactTrackingContext.Provider value={this.contextValueForProvider}>
             <DecoratedComponent {...this.props} tracking={this.tracking} />
           </ReactTrackingContext.Provider>
         );

--- a/src/withTrackingComponentDecorator.js
+++ b/src/withTrackingComponentDecorator.js
@@ -38,13 +38,13 @@ export default function withTrackingComponentDecorator(
 
         this.tracking = {
           trackEvent: this.trackEvent,
-          getTrackingData: this.getTrackingData(),
+          getTrackingData: this.getTrackingDataFn(),
         };
 
         this.contextValueForProvider = {
           tracking: {
             dispatch: this.getTrackingDispatcher(),
-            getTrackingData: this.getTrackingData(),
+            getTrackingData: this.getTrackingDataFn(),
             process: this.getProcessFn() || process,
           },
         };
@@ -88,7 +88,7 @@ export default function withTrackingComponentDecorator(
         return ownTrackingData || {};
       };
 
-      getTrackingData = () => {
+      getTrackingDataFn = () => {
         const { tracking } = this.context;
         const contextGetTrackingData =
           (tracking && tracking.getTrackingData) || this.getOwnTrackingData;


### PR DESCRIPTION
The React 16 context has slightly different behavior when dealing with updates in a subtree. With the legacy context, a `shouldComponentUpdate` returning false in a component tree would cause the context consumers in its subtree to not receive context updates. From the React docs:

> The problem is, if a context value provided by component changes, descendants that use that value won’t update if an intermediate parent returns false from shouldComponentUpdate.
-- https://reactjs.org/docs/legacy-context.html#updating-context

With the new context introduced in React 16, the context consumers will always update regardless of a parent's optimizations:
> All consumers that are descendants of a Provider will re-render whenever the Provider’s value prop changes. The propagation from Provider to its descendant consumers is not subject to the shouldComponentUpdate method, so the consumer is updated even when an ancestor component bails out of the update.
-- https://reactjs.org/docs/context.html#contextprovider

What we encountered within our application was that after the upgrade we were seeing significantly more re-renders of our component trees than before, causing some performance issues. 

We were able to fix the re-render regressions by rewriting how the context is structured and how data is merged in a tree of components decorated with `track`.

Instead of eagerly computing the tracking context data, we are providing a callback on the context that will merge the data bottom-up. We also changed the dispatch function to use a similar mechanism. This has the benefit of the context value having stable referential equality, so there are no extra renders caused by the context provider updating with the eagerly computed tracking data.

We forked `react-tracking` internally and made these updates, which we have been using for a few weeks. These changes brought our performance metrics back to where they were before the `react-tracking@6` upgrade. We also added a test case in the `e2e` test suite which represents the expected behavior (the test case fails on the current master branch).

This technically changes the context shape as we removed `context.tracking.data` and replaced it with `context.tracking.getTrackingData()`, so it will require a major version bump.

**Simple reproduction case:**
6.0.0 behavior: https://codesandbox.io/s/frosty-bouman-7hfmr
5.7.0 behavior: https://codesandbox.io/s/mmq0zn57jp

Thanks!

_Co-authored with: @jacekradko_