### PR TITLE
Massage exports

### DIFF
--- a/src/__tests__/e2e.test.js
+++ b/src/__tests__/e2e.test.js
@@ -12,7 +12,7 @@ const testState = { booleanState: true };
 
 describe('e2e', () => {
   // eslint-disable-next-line global-require
-  const { default: track, useTracking, ReactTrackingContext } = require('../');
+  const { default: track, useTracking } = require('../');
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -633,6 +633,10 @@ describe('e2e', () => {
   });
 
   it('root context items are accessible to children', () => {
+    const {
+      ReactTrackingContext,
+    } = require('../withTrackingComponentDecorator'); // eslint-disable-line global-require
+
     const App = track()(() => {
       return <Child />;
     });

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -17,7 +17,13 @@ describe('react-tracking', () => {
   it('exports TrackingPropType', () => {
     expect(index.TrackingPropType).toBeDefined();
   });
+  it('exports track', () => {
+    expect(index.track).toBeDefined();
+  });
   it('exports default function', () => {
     expect(typeof index.default).toBe('function');
+  });
+  it('track and default export are the same', () => {
+    expect(index.track).toBe(index.default);
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
+import track from './trackingHoC';
+
 export {
   default as withTracking,
-  ReactTrackingContext,
   TrackingContextType,
 } from './withTrackingComponentDecorator';
 export { default as trackEvent } from './trackEventMethodDecorator';
 export { default as TrackingPropType } from './TrackingPropType';
 export { default as useTracking } from './useTracking';
-export { default } from './trackingHoC';
+
+export { track, track as default };


### PR DESCRIPTION
- Default and named `track` export
- Remove ReactTrackingContext from public exports since it's an implementation detail