### PR TITLE
Add eslint react hooks plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,15 @@
 module.exports = {
   parser: 'babel-eslint',
   extends: ['airbnb', 'plugin:prettier/recommended', 'prettier/react'],
-  plugins: ['prettier'],
+  plugins: ['prettier', 'react-hooks'],
   env: {
     jest: true,
     browser: true,
   },
   rules: {
     'prettier/prettier': 'error',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
     'react/jsx-filename-extension': [
       1,
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2677,9 +2677,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
-      "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.2.tgz",
+      "integrity": "sha512-S1FfZpeBchkhyoY76YAdFzKS4zz9aOK7EeFaNA2aJlyXyA+sgqz6xdxmLPGXEAf0nF44MVN1kSjrA9Kt3ATDQg=="
     },
     "core-js-compat": {
       "version": "3.2.1",
@@ -3124,18 +3124,18 @@
       }
     },
     "enzyme-adapter-react-16": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.0.tgz",
-      "integrity": "sha512-p5k5TAG9hiyFNgJ7ABkfg5Poc3Gp5D2uArDEv7BW/FE0AflqIRfHFi4G3Ei+MpPuwy5Ao+ZisYWKuxC5LRCr1Q==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.1.tgz",
+      "integrity": "sha512-yMPxrP3vjJP+4wL/qqfkT6JAIctcwKF+zXO6utlGPgUJT2l4tzrdjMDWGd/Pp1BjHBcljhN24OzNEGRteibJhA==",
       "dev": true,
       "requires": {
-        "enzyme-adapter-utils": "^1.12.0",
+        "enzyme-adapter-utils": "^1.12.1",
         "enzyme-shallow-equal": "^1.0.0",
         "has": "^1.0.3",
         "object.assign": "^4.1.0",
         "object.values": "^1.1.0",
         "prop-types": "^15.7.2",
-        "react-is": "^16.8.6",
+        "react-is": "^16.10.2",
         "react-test-renderer": "^16.0.0-0",
         "semver": "^5.7.0"
       },
@@ -3512,6 +3512,12 @@
           }
         }
       }
+    },
+    "eslint-plugin-react-hooks": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.1.2.tgz",
+      "integrity": "sha512-ZR+AyesAUGxJAyTFlF3MbzeVHAcQTFQt1fFVe5o0dzY/HFoj1dgQDMoIkiM+ltN/HhlHBYX4JpJwYonjxsyQMA==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.0.0",
@@ -4875,20 +4881,20 @@
       }
     },
     "husky": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-3.0.8.tgz",
-      "integrity": "sha512-HFOsgcyrX3qe/rBuqyTt+P4Gxn5P0seJmr215LAZ/vnwK3jWB3r0ck7swbzGRUbufCf9w/lgHPVbF/YXQALgfQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-3.0.9.tgz",
+      "integrity": "sha512-Yolhupm7le2/MqC1VYLk/cNmYxsSsqKkTyBhzQHhPK1jFnC89mmmNVuGtLNabjDI6Aj8UNIr0KpRNuBkiC4+sg==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
+        "ci-info": "^2.0.0",
         "cosmiconfig": "^5.2.1",
         "execa": "^1.0.0",
         "get-stdin": "^7.0.0",
-        "is-ci": "^2.0.0",
         "opencollective-postinstall": "^2.0.2",
         "pkg-dir": "^4.2.0",
         "please-upgrade-node": "^3.2.0",
-        "read-pkg": "^5.1.1",
+        "read-pkg": "^5.2.0",
         "run-node": "^1.0.0",
         "slash": "^3.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     ]
   },
   "dependencies": {
-    "core-js": "^3.2.1",
+    "core-js": "^3.3.2",
     "deepmerge": "^4.1.1",
     "hoist-non-react-statics": "^3.3.0"
   },
@@ -86,7 +86,7 @@
     "babel-eslint": "^10.0.3",
     "babel-plugin-transform-decorators-legacy": "^1.3.5",
     "enzyme": "^3.10.0",
-    "enzyme-adapter-react-16": "^1.15.0",
+    "enzyme-adapter-react-16": "^1.15.1",
     "eslint": "^6.5.1",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^6.4.0",
@@ -94,7 +94,8 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.16.0",
-    "husky": "^3.0.8",
+    "eslint-plugin-react-hooks": "^2.1.2",
+    "husky": "^3.0.9",
     "jest": "^24.9.0",
     "lint-staged": "^9.4.2",
     "prettier": "^1.18.2",


### PR DESCRIPTION
Figured we should probably pull in [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) since we're making heavy use of them now.

At first I applied the auto-fix for all issues, but that broke one of the e2e tests: `does not cause unnecessary updates due to context changes` -- and that's a critical one for performance reasons. So I had to selectively eslint-disable the `tracking` dependency in the hooks dependency array for a couple of the hooks. Not sure if there's a more idiomatic way around that?

Admittedly, I haven't personally used Hooks too much myself, so I'm definitely keen to hear your feedback on this, @bgergen if you could take a look when you get a chance 🙏 