### PR TITLE
Remove TrackingContextType, test useTracking export

### DIFF
--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -11,8 +11,8 @@ describe('react-tracking', () => {
   it('exports trackEvent', () => {
     expect(index.trackEvent).toBeDefined();
   });
-  it('exports TrackingContextType', () => {
-    expect(index.TrackingContextType).toBeDefined();
+  it('exports useTracking', () => {
+    expect(index.useTracking).toBeDefined();
   });
   it('exports TrackingPropType', () => {
     expect(index.TrackingPropType).toBeDefined();

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,6 @@
 import track from './trackingHoC';
 
-export {
-  default as withTracking,
-  TrackingContextType,
-} from './withTrackingComponentDecorator';
+export { default as withTracking } from './withTrackingComponentDecorator';
 export { default as trackEvent } from './trackEventMethodDecorator';
 export { default as TrackingPropType } from './TrackingPropType';
 export { default as useTracking } from './useTracking';

--- a/src/withTrackingComponentDecorator.js
+++ b/src/withTrackingComponentDecorator.js
@@ -6,17 +6,10 @@ import React, {
   useMemo,
   useRef,
 } from 'react';
-import PropTypes from 'prop-types';
 import merge from 'deepmerge';
 import hoistNonReactStatic from 'hoist-non-react-statics';
 
 import dispatchTrackingEvent from './dispatchTrackingEvent';
-
-export const TrackingContextType = PropTypes.shape({
-  data: PropTypes.object,
-  dispatch: PropTypes.func,
-  process: PropTypes.func,
-});
 
 export const ReactTrackingContext = React.createContext({});
 


### PR DESCRIPTION
This PR removes `TrackingContextType`, which I believe is leftover from an era when the library used the legacy context API. As far as I can tell it no longer provides any value. I also removed the test that checked for the context type export and replaced it with the same check for the `useTracking` hook.