### PR TITLE
remove core-js as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     ]
   },
   "dependencies": {
-    "core-js": "^3.3.2",
     "deepmerge": "^4.1.1",
     "hoist-non-react-statics": "^3.3.0"
   },


### PR DESCRIPTION
Hi! We use core-js and we noticed that it pulls in core-js but doesn't actually import it. I... think? Perhaps I'm wrong!