### PR TITLE
Expand useTracking API to accept contextual data

### DIFF
--- a/src/ReactTrackingContext.js
+++ b/src/ReactTrackingContext.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default React.createContext({});

--- a/src/__tests__/e2e.test.js
+++ b/src/__tests__/e2e.test.js
@@ -711,9 +711,7 @@ describe('e2e', () => {
   });
 
   it('root context items are accessible to children', () => {
-    const {
-      ReactTrackingContext,
-    } = require('../withTrackingComponentDecorator'); // eslint-disable-line global-require
+    const { ReactTrackingContext } = require('../useTracking'); // eslint-disable-line global-require
 
     const App = track()(() => {
       return <Child />;

--- a/src/__tests__/e2e.test.js
+++ b/src/__tests__/e2e.test.js
@@ -711,7 +711,7 @@ describe('e2e', () => {
   });
 
   it('root context items are accessible to children', () => {
-    const { ReactTrackingContext } = require('../useTrackingImpl'); // eslint-disable-line global-require
+    const ReactTrackingContext = require('../ReactTrackingContext').default; // eslint-disable-line global-require
 
     const App = track()(() => {
       return <Child />;

--- a/src/__tests__/e2e.test.js
+++ b/src/__tests__/e2e.test.js
@@ -802,8 +802,10 @@ describe('e2e', () => {
       }
     }
 
-    // Get the first child since the page is wrapped with the WithTracking component.
-    const page = await mount(<Page />).childAt(0);
+    // Get the children's children since Page is wrapped with the WithTracking & Track components.
+    const page = await mount(<Page />)
+      .children()
+      .children();
     await page.instance().executeAction();
 
     expect(page.state().data).toEqual(message);
@@ -853,8 +855,10 @@ describe('e2e', () => {
       }
     }
 
-    // Get the first child since the page is wrapped with the WithTracking component.
-    const page = await mount(<Page />).childAt(0);
+    // Get the children's children since Page is wrapped with the WithTracking & Track components.
+    const page = await mount(<Page />)
+      .children()
+      .children();
     await page.instance().executeAction();
 
     expect(page.state().data).toEqual(message);

--- a/src/__tests__/e2e.test.js
+++ b/src/__tests__/e2e.test.js
@@ -711,7 +711,7 @@ describe('e2e', () => {
   });
 
   it('root context items are accessible to children', () => {
-    const { ReactTrackingContext } = require('../useTracking'); // eslint-disable-line global-require
+    const { ReactTrackingContext } = require('../useTrackingImpl'); // eslint-disable-line global-require
 
     const App = track()(() => {
       return <Child />;
@@ -802,10 +802,8 @@ describe('e2e', () => {
       }
     }
 
-    // Get the children's children since Page is wrapped with the WithTracking & Track components.
-    const page = await mount(<Page />)
-      .children()
-      .children();
+    // Get the first child since the page is wrapped with the WithTracking component.
+    const page = await mount(<Page />).childAt(0);
     await page.instance().executeAction();
 
     expect(page.state().data).toEqual(message);
@@ -855,10 +853,8 @@ describe('e2e', () => {
       }
     }
 
-    // Get the children's children since Page is wrapped with the WithTracking & Track components.
-    const page = await mount(<Page />)
-      .children()
-      .children();
+    // Get the first child since the page is wrapped with the WithTracking component.
+    const page = await mount(<Page />).childAt(0);
     await page.instance().executeAction();
 
     expect(page.state().data).toEqual(message);

--- a/src/__tests__/hooks.test.js
+++ b/src/__tests__/hooks.test.js
@@ -3,6 +3,7 @@
 /* eslint-disable react/destructuring-assignment,react/no-multi-comp,react/prop-types,react/prefer-stateless-function  */
 /* eslint-disable jsx-a11y/control-has-associated-label */
 import React, { useContext, useEffect, useState } from 'react';
+import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 
 const dispatchTrackingEvent = jest.fn();
@@ -833,8 +834,9 @@ describe('hooks', () => {
     };
 
     const page = await mount(<Page />);
-    await page.find('button').simulate('click');
-    await new Promise(resolve => setTimeout(resolve));
+    await act(() => {
+      page.find('button').simulate('click');
+    });
 
     expect(page.text()).toEqual(message);
     expect(dispatchTrackingEvent).toHaveBeenCalledTimes(1);

--- a/src/__tests__/hooks.test.js
+++ b/src/__tests__/hooks.test.js
@@ -802,7 +802,7 @@ describe('hooks', () => {
     });
   });
 
-  it('dispatches tracking event from async function', async () => {
+  it.skip('dispatches tracking event from async function', async () => {
     const message = { value: 'test' };
 
     let executeAction;
@@ -844,7 +844,7 @@ describe('hooks', () => {
     });
   });
 
-  it('handles rejected async function', async () => {
+  it.skip('handles rejected async function', async () => {
     const message = { value: 'error' };
 
     let executeAction;
@@ -887,7 +887,7 @@ describe('hooks', () => {
     });
   });
 
-  it('can access wrapped component by ref', async () => {
+  it.skip('can access wrapped component by ref', async () => {
     const focusFn = jest.fn();
 
     const Child = React.forwardRef((props, ref) => {

--- a/src/__tests__/hooks.test.js
+++ b/src/__tests__/hooks.test.js
@@ -53,8 +53,7 @@ describe('hooks', () => {
     const testPageData = { page: 'TestPage' };
 
     const TestPage = () => {
-      const { Track } = useTracking(testPageData, { dispatchOnMount: true });
-
+      useTracking(testPageData, { dispatchOnMount: true });
       return null;
     };
 

--- a/src/__tests__/hooks.test.js
+++ b/src/__tests__/hooks.test.js
@@ -54,7 +54,7 @@ describe('hooks', () => {
     const TestPage = () => {
       const { Track } = useTracking(testPageData, { dispatchOnMount: true });
 
-      return <Track>{null}</Track>;
+      return null;
     };
 
     mount(<TestPage />);

--- a/src/__tests__/hooks.test.js
+++ b/src/__tests__/hooks.test.js
@@ -663,8 +663,9 @@ describe('hooks', () => {
       useTracking(
         {},
         {
+          dispatch,
           dispatchOnMount: () => {
-            dispatchCount += 1;
+            return { test: true };
           },
         }
       );

--- a/src/__tests__/hooks.test.js
+++ b/src/__tests__/hooks.test.js
@@ -802,8 +802,8 @@ describe('hooks', () => {
     });
   });
 
-  it.skip('dispatches tracking event from async function', async () => {
-    const message = { value: 'test' };
+  it('dispatches tracking event from async function', async () => {
+    const message = 'test';
 
     let executeAction;
     const Page = () => {
@@ -829,23 +829,20 @@ describe('hooks', () => {
       return <div>{state && state.data}</div>;
     };
 
-    // Get the first child since the page is wrapped with the WithTracking component.
-    const page = await mount(<Page />).childAt(0);
-    await page.instance().executeAction(); // TODO: this probably doesn't work (how well does Enzyme support hooks?)
-    // TODO: maybe have to just call executeAction(); here
-    executeAction();
+    const page = await mount(<Page />);
+    await executeAction();
 
-    expect(page.state().data).toEqual(message);
+    expect(page.text()).toEqual(message);
     expect(dispatchTrackingEvent).toHaveBeenCalledTimes(1);
     expect(dispatchTrackingEvent).toHaveBeenCalledWith({
       label: 'async action',
       status: 'success',
-      ...message,
+      value: message,
     });
   });
 
-  it.skip('handles rejected async function', async () => {
-    const message = { value: 'error' };
+  it('handles rejected async function', async () => {
+    const message = 'error';
 
     let executeAction;
     const Page = () => {
@@ -873,13 +870,11 @@ describe('hooks', () => {
       return <div>{state && state.data}</div>;
     };
 
-    // Get the first child since the page is wrapped with the WithTracking component.
-    const page = await mount(<Page />).childAt(0);
-    await page.instance().executeAction();
+    const page = await mount(<Page />);
     // TODO: redundant with previous test perhaps, but here for posterity. Similarly we may need to call executeAction(); directly
-    executeAction();
+    await executeAction();
 
-    expect(page.state().data).toEqual(message);
+    expect(page.text()).toEqual(message);
     expect(dispatchTrackingEvent).toHaveBeenCalledTimes(1);
     expect(dispatchTrackingEvent).toHaveBeenCalledWith({
       label: 'async action',

--- a/src/__tests__/hooks.test.js
+++ b/src/__tests__/hooks.test.js
@@ -739,7 +739,7 @@ describe('hooks', () => {
   });
 
   it('root context items are accessible to children', () => {
-    const { ReactTrackingContext } = require('../useTracking'); // eslint-disable-line global-require
+    const { ReactTrackingContext } = require('../useTrackingImpl'); // eslint-disable-line global-require
 
     const Child = () => {
       const trackingContext = useContext(ReactTrackingContext);
@@ -880,35 +880,5 @@ describe('hooks', () => {
       label: 'async action',
       status: 'failed',
     });
-  });
-
-  it.skip('can access wrapped component by ref', async () => {
-    const focusFn = jest.fn();
-
-    const Child = React.forwardRef((props, ref) => {
-      const { Track } = useTracking({});
-
-      return (
-        <Track>
-          <button ref={ref} onFocus={focusFn} type="button">
-            child
-          </button>
-        </Track>
-      );
-    });
-
-    const ref = React.createRef();
-    const Parent = () => {
-      useEffect(() => {
-        ref.current.focus();
-      }, []);
-
-      return <Child ref={ref} />;
-    };
-
-    const parent = await mount(<Parent />);
-
-    expect(parent.instance().child).not.toBeNull(); // TODO: probably need to rethink how this test works
-    expect(focusFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/hooks.test.js
+++ b/src/__tests__/hooks.test.js
@@ -738,7 +738,7 @@ describe('hooks', () => {
   });
 
   it('root context items are accessible to children', () => {
-    const { ReactTrackingContext } = require('../useTrackingImpl'); // eslint-disable-line global-require
+    const ReactTrackingContext = require('../ReactTrackingContext').default; // eslint-disable-line global-require
 
     const Child = () => {
       const trackingContext = useContext(ReactTrackingContext);

--- a/src/__tests__/hooks.test.js
+++ b/src/__tests__/hooks.test.js
@@ -54,7 +54,7 @@ describe('hooks', () => {
     const TestPage = () => {
       const { Track } = useTracking(testPageData, { dispatchOnMount: true });
 
-      return <Track>{null}</Track>; // TODO: what does it mean for the API if this was <Track dispatchOnMount /> instead of useTracking({ dispatchOnMount: true }) above?
+      return <Track>{null}</Track>;
     };
 
     mount(<TestPage />);
@@ -66,7 +66,7 @@ describe('hooks', () => {
 
   it('accepts a dispatch function in options', () => {
     const TestOptions = () => {
-      const { trackEvent } = useTracking(testDataContext, { dispatch }); // TODO: should we accept top-level config options here?
+      const { trackEvent } = useTracking(testDataContext, { dispatch });
 
       const blah = () => {
         trackEvent(testData);
@@ -95,7 +95,7 @@ describe('hooks', () => {
     };
 
     const TestChild = () => {
-      useTracking(testChildData, { dispatchOnMount: true }); // TODO: Should these properties instead be on the <Track /> component and we require the user to "render" it?
+      useTracking(testChildData, { dispatchOnMount: true });
       return <div />;
     };
 
@@ -163,7 +163,7 @@ describe('hooks', () => {
     const dispatchOnMount = jest.fn(() => ({ dom: true }));
 
     const TestComponent = () => {
-      useTracking(testDispatchOnMount, { dispatch, dispatchOnMount }); // TODO: potential recipe here is if a component does not render children, it doesn't need to include <Track /> in the tree!
+      useTracking(testDispatchOnMount, { dispatch, dispatchOnMount });
       return null;
     };
 
@@ -192,7 +192,7 @@ describe('hooks', () => {
     };
 
     const Page = () => {
-      useTracking({ page: 'Page' }); // TODO: Does this pass? It doesn't render children so we should still get all the proper tracking context dispatched on mount according to "process" fn above
+      useTracking({ page: 'Page' });
       return <div>Page</div>;
     };
 
@@ -210,7 +210,6 @@ describe('hooks', () => {
   });
 
   it('will dispatch a pageview event on mount on functional component', () => {
-    // TODO: Using purely hooks API, this test is redundant with above, but we will keep it for parity
     const App = ({ children }) => {
       const { Track } = useTracking(
         { topLevel: true },
@@ -376,7 +375,7 @@ describe('hooks', () => {
     };
 
     const Page = ({ runtimeData }) => {
-      useTracking({ page: 'Page', runtimeData }); // TODO: in this case we were able to derive props.runtimeData "statically" from within the component, does this still work as expected?
+      useTracking({ page: 'Page', runtimeData });
       return <div>Page</div>;
     };
 
@@ -805,7 +804,6 @@ describe('hooks', () => {
   it('dispatches tracking event from async function', async () => {
     const message = 'test';
 
-    let executeAction;
     const Page = () => {
       const [state, setState] = useState({});
       const { trackEvent } = useTracking();
@@ -821,16 +819,22 @@ describe('hooks', () => {
         return value;
       };
 
-      executeAction = async () => {
+      const executeAction = async () => {
         const data = await handleAsyncAction();
         setState({ data });
       };
 
-      return <div>{state && state.data}</div>;
+      return (
+        <>
+          <button type="button" onClick={executeAction} />
+          <div>{state && state.data}</div>
+        </>
+      );
     };
 
     const page = await mount(<Page />);
-    await executeAction();
+    await page.find('button').simulate('click');
+    await new Promise(resolve => setTimeout(resolve));
 
     expect(page.text()).toEqual(message);
     expect(dispatchTrackingEvent).toHaveBeenCalledTimes(1);
@@ -844,7 +848,6 @@ describe('hooks', () => {
   it('handles rejected async function', async () => {
     const message = 'error';
 
-    let executeAction;
     const Page = () => {
       const [state, setState] = useState({});
       const { trackEvent } = useTracking();
@@ -853,7 +856,7 @@ describe('hooks', () => {
         return Promise.reject(message);
       };
 
-      executeAction = async () => {
+      const executeAction = async () => {
         try {
           const data = await handleAsyncAction();
           setState({ data });
@@ -867,12 +870,16 @@ describe('hooks', () => {
         }
       };
 
-      return <div>{state && state.data}</div>;
+      return (
+        <>
+          <button type="button" onClick={executeAction} />
+          <div>{state && state.data}</div>
+        </>
+      );
     };
 
     const page = await mount(<Page />);
-    // TODO: redundant with previous test perhaps, but here for posterity. Similarly we may need to call executeAction(); directly
-    await executeAction();
+    await page.find('button').simulate('click');
 
     expect(page.text()).toEqual(message);
     expect(dispatchTrackingEvent).toHaveBeenCalledTimes(1);

--- a/src/__tests__/hooks.test.js
+++ b/src/__tests__/hooks.test.js
@@ -52,7 +52,7 @@ describe('hooks', () => {
     const testPageData = { page: 'TestPage' };
 
     const TestPage = () => {
-      const { Track } = useTracking({}, { dispatchOnMount: true });
+      const { Track } = useTracking(testPageData, { dispatchOnMount: true });
 
       return <Track>{null}</Track>; // TODO: what does it mean for the API if this was <Track dispatchOnMount /> instead of useTracking({ dispatchOnMount: true }) above?
     };
@@ -89,13 +89,9 @@ describe('hooks', () => {
     const testChildData = { page: 'TestChild' };
 
     const TestOptions = ({ children }) => {
-      const { Track } = useTracking();
+      const { Track } = useTracking(testDataContext, { dispatch });
 
-      return (
-        <Track data={testDataContext} dispatch={dispatch}>
-          {children}
-        </Track>
-      );
+      return <Track>{children}</Track>;
     };
 
     const TestChild = () => {
@@ -491,8 +487,8 @@ describe('hooks', () => {
   it('can read tracking data from props.tracking.getTrackingData()', () => {
     const mockReader = jest.fn();
 
-    const TestOptions = ({ onProps, children }) => {
-      const { Track } = useTracking({ onProps, ...testDataContext });
+    const TestOptions = ({ onProps, child, children }) => {
+      const { Track } = useTracking({ onProps, child, ...testDataContext });
       return <Track>{children}</Track>;
     };
 
@@ -503,7 +499,7 @@ describe('hooks', () => {
     };
 
     mount(
-      <TestOptions onProps="yes">
+      <TestOptions onProps="yes" child>
         <TestChild />
       </TestOptions>
     );
@@ -657,7 +653,7 @@ describe('hooks', () => {
 
   it('can interop with the HoC (where HoC is top-level)', () => {
     const mockDispatchTrackingEvent = jest.fn();
-    const testData1 = { key: { x: 1, y: 1, topLevel: 'hoc' } };
+    const testData1 = { key: { x: 1, y: 1 }, topLevel: 'hoc' };
     const testData2 = { key: { x: 2, z: 2 }, page: 'TestDeepMerge' };
 
     // functional wrapper hoc
@@ -743,9 +739,7 @@ describe('hooks', () => {
   });
 
   it('root context items are accessible to children', () => {
-    const {
-      ReactTrackingContext,
-    } = require('../withTrackingComponentDecorator'); // eslint-disable-line global-require
+    const { ReactTrackingContext } = require('../useTracking'); // eslint-disable-line global-require
 
     const Child = () => {
       const trackingContext = useContext(ReactTrackingContext);

--- a/src/__tests__/hooks.test.js
+++ b/src/__tests__/hooks.test.js
@@ -13,7 +13,7 @@ const testData = { testData: true };
 const dispatch = jest.fn();
 const testState = { booleanState: true };
 
-describe.skip('hooks', () => {
+describe('hooks', () => {
   // eslint-disable-next-line global-require
   const { default: track, useTracking } = require('../');
 
@@ -416,12 +416,12 @@ describe.skip('hooks', () => {
       return <Track>{children}</Track>;
     };
     const Page = ({ children }) => {
-      const Track = useTracking({ page: 'Page' });
+      const { Track } = useTracking({ page: 'Page' });
       return <Track>{children}</Track>;
     };
 
     const Nested = ({ children }) => {
-      const Track = useTracking({ view: 'View' });
+      const { Track } = useTracking({ view: 'View' });
       return <Track>{children}</Track>;
     };
 

--- a/src/__tests__/hooks.test.js
+++ b/src/__tests__/hooks.test.js
@@ -515,7 +515,9 @@ describe('hooks', () => {
   });
 
   it('logs a console error when there is already a process defined on context', () => {
-    global.console.error = jest.fn();
+    const consoleError = jest
+      .spyOn(global.console, 'error')
+      .mockImplementation(() => {});
     const process = () => {};
 
     const NestedComponent = () => {
@@ -546,10 +548,12 @@ describe('hooks', () => {
 
     mount(<TestComponent />);
 
-    expect(global.console.error).toHaveBeenCalledTimes(1);
-    expect(global.console.error).toHaveBeenCalledWith(
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith(
       '[react-tracking] options.process should be defined once on a top-level component'
     );
+
+    consoleError.mockRestore();
   });
 
   it('will dispatch different data if props changed', () => {
@@ -834,8 +838,8 @@ describe('hooks', () => {
     };
 
     const page = await mount(<Page />);
-    await act(() => {
-      page.find('button').simulate('click');
+    await act(async () => {
+      await page.find('button').simulate('click');
     });
 
     expect(page.text()).toEqual(message);
@@ -881,7 +885,9 @@ describe('hooks', () => {
     };
 
     const page = await mount(<Page />);
-    await page.find('button').simulate('click');
+    await act(async () => {
+      await page.find('button').simulate('click');
+    });
 
     expect(page.text()).toEqual(message);
     expect(dispatchTrackingEvent).toHaveBeenCalledTimes(1);

--- a/src/__tests__/useTracking.test.js
+++ b/src/__tests__/useTracking.test.js
@@ -1,25 +1,9 @@
 /* eslint-disable jsx-a11y/control-has-associated-label */
 import { mount } from 'enzyme';
 import React from 'react';
-import { renderToString } from 'react-dom/server';
-import track from '../withTrackingComponentDecorator';
 import useTracking from '../useTracking';
 
 describe('useTracking', () => {
-  it('throws error if tracking context not present', () => {
-    const ThrowMissingContext = () => {
-      useTracking();
-      return <div>hi</div>;
-    };
-    try {
-      renderToString(<ThrowMissingContext />);
-    } catch (error) {
-      expect(error.message).toContain(
-        'Attempting to call `useTracking` without a ReactTrackingContext present'
-      );
-    }
-  });
-
   it('dispatches tracking events from a useTracking hook tracking object', () => {
     const outerTrackingData = {
       page: 'Page',
@@ -27,8 +11,8 @@ describe('useTracking', () => {
 
     const dispatch = jest.fn();
 
-    const App = track(outerTrackingData, { dispatch })(() => {
-      const tracking = useTracking();
+    const App = () => {
+      const tracking = useTracking(outerTrackingData, { dispatch });
 
       expect(tracking.getTrackingData()).toEqual({
         page: 'Page',
@@ -44,7 +28,7 @@ describe('useTracking', () => {
           }
         />
       );
-    });
+    };
 
     const wrapper = mount(<App />);
     wrapper.simulate('click');

--- a/src/__tests__/useTracking.test.js
+++ b/src/__tests__/useTracking.test.js
@@ -1,9 +1,25 @@
 /* eslint-disable jsx-a11y/control-has-associated-label */
 import { mount } from 'enzyme';
 import React from 'react';
+import { renderToString } from 'react-dom/server';
 import useTracking from '../useTracking';
 
 describe('useTracking', () => {
+  it('does not throw an error if tracking context not present', () => {
+    const ThrowMissingContext = () => {
+      useTracking();
+      return <div>hi</div>;
+    };
+
+    expect(() => {
+      try {
+        renderToString(<ThrowMissingContext />);
+      } catch (error) {
+        throw new Error(error);
+      }
+    }).not.toThrow();
+  });
+
   it('dispatches tracking events from a useTracking hook tracking object', () => {
     const outerTrackingData = {
       page: 'Page',

--- a/src/useTracking.js
+++ b/src/useTracking.js
@@ -11,14 +11,6 @@ export default function useTracking(
 ) {
   const trackingContext = useContext(ReactTrackingContext);
 
-  // if (!(trackingContext && trackingContext.tracking)) {
-  //   throw new Error(
-  //     'Attempting to call `useTracking` ' +
-  //       'without a ReactTrackingContext present. Did you forget to wrap the top of ' +
-  //       'your component tree with `track`?'
-  //   );
-  // }
-
   // statically extract tracking.process for hook dependency
   const tracking = useMemo(() => trackingContext.tracking || {}, [
     trackingContext.tracking,

--- a/src/useTracking.js
+++ b/src/useTracking.js
@@ -9,14 +9,11 @@ export default function useTracking(
   trackingData = {},
   { dispatch = dispatchTrackingEvent, dispatchOnMount = false, process } = {}
 ) {
-  const trackingContext = useContext(ReactTrackingContext);
+  const { tracking } = useContext(ReactTrackingContext);
 
-  // statically extract tracking.process for hook dependency
-  const tracking = useMemo(() => trackingContext.tracking || {}, [
-    trackingContext.tracking,
+  const getProcessFn = useCallback(() => tracking && tracking.process, [
+    tracking,
   ]);
-  const trkProcess = tracking.process;
-  const getProcessFn = useCallback(() => trkProcess, [trkProcess]);
 
   const getOwnTrackingData = useCallback(() => {
     const ownTrackingData =

--- a/src/useTracking.js
+++ b/src/useTracking.js
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 
-import useTrackingImpl, { ReactTrackingContext } from './useTrackingImpl';
+import ReactTrackingContext from './ReactTrackingContext';
+import useTrackingImpl from './useTrackingImpl';
 
 export default function useTracking(trackingData, options) {
   const contextValue = useTrackingImpl(trackingData, options);

--- a/src/useTracking.js
+++ b/src/useTracking.js
@@ -1,107 +1,11 @@
-import React, { useCallback, useContext, useEffect, useMemo } from 'react';
-import merge from 'deepmerge';
+import React, { useCallback, useMemo } from 'react';
 
-import dispatchTrackingEvent from './dispatchTrackingEvent';
+import useTrackingImpl, { ReactTrackingContext } from './useTrackingImpl';
 
-export const ReactTrackingContext = React.createContext({});
+export default function useTracking(trackingData, options) {
+  const contextValue = useTrackingImpl(trackingData, options);
 
-export default function useTracking(
-  trackingData = {},
-  { dispatch = dispatchTrackingEvent, dispatchOnMount = false, process } = {}
-) {
-  const { tracking } = useContext(ReactTrackingContext);
-
-  const getProcessFn = useCallback(() => tracking && tracking.process, [
-    tracking,
-  ]);
-
-  const getOwnTrackingData = useCallback(() => {
-    const ownTrackingData =
-      typeof trackingData === 'function' ? trackingData() : trackingData;
-    return ownTrackingData || {};
-  }, [trackingData]);
-
-  const getTrackingDataFn = useCallback(() => {
-    const contextGetTrackingData =
-      (tracking && tracking.getTrackingData) || getOwnTrackingData;
-
-    return () =>
-      contextGetTrackingData === getOwnTrackingData
-        ? getOwnTrackingData()
-        : merge(contextGetTrackingData(), getOwnTrackingData());
-  }, [getOwnTrackingData, tracking]);
-
-  const getTrackingDispatcher = useCallback(() => {
-    const contextDispatch = (tracking && tracking.dispatch) || dispatch;
-    return data => contextDispatch(merge(getOwnTrackingData(), data || {}));
-  }, [getOwnTrackingData, tracking, dispatch]);
-
-  const trackEvent = useCallback(
-    (data = {}) => {
-      getTrackingDispatcher()(data);
-    },
-    [getTrackingDispatcher]
-  );
-
-  useEffect(() => {
-    const contextProcess = getProcessFn();
-    const getTrackingData = getTrackingDataFn();
-
-    if (contextProcess && process) {
-      // eslint-disable-next-line
-      console.error(
-        '[react-tracking] options.process should be defined once on a top-level component'
-      );
-    }
-
-    if (
-      typeof contextProcess === 'function' &&
-      typeof dispatchOnMount === 'function'
-    ) {
-      trackEvent(
-        merge(
-          contextProcess(getOwnTrackingData()) || {},
-          dispatchOnMount(getTrackingData()) || {}
-        )
-      );
-    } else if (typeof contextProcess === 'function') {
-      const processed = contextProcess(getOwnTrackingData());
-      if (processed || dispatchOnMount === true) {
-        trackEvent(processed);
-      }
-    } else if (typeof dispatchOnMount === 'function') {
-      trackEvent(dispatchOnMount(getTrackingData()));
-    } else if (dispatchOnMount === true) {
-      trackEvent();
-    }
-  }, [
-    getOwnTrackingData,
-    getProcessFn,
-    getTrackingDataFn,
-    trackEvent,
-    dispatchOnMount,
-    process,
-  ]);
-
-  const nextDispatch = useMemo(() => getTrackingDispatcher(), [
-    getTrackingDispatcher,
-  ]);
-  const nextGetTrackingData = useMemo(() => getTrackingDataFn(), [
-    getTrackingDataFn,
-  ]);
-
-  const contextValue = useMemo(
-    () => ({
-      tracking: {
-        dispatch: nextDispatch,
-        getTrackingData: nextGetTrackingData,
-        process: getProcessFn() || process,
-      },
-    }),
-    [nextDispatch, nextGetTrackingData, getProcessFn, process]
-  );
-
-  const TrackingProvider = useCallback(
+  const Track = useCallback(
     ({ children }) => (
       <ReactTrackingContext.Provider value={contextValue}>
         {children}
@@ -112,10 +16,10 @@ export default function useTracking(
 
   return useMemo(
     () => ({
-      getTrackingData: nextGetTrackingData,
-      trackEvent: nextDispatch,
-      Track: TrackingProvider,
+      Track,
+      getTrackingData: contextValue.tracking.getTrackingData,
+      trackEvent: contextValue.tracking.dispatch,
     }),
-    [nextDispatch, nextGetTrackingData, TrackingProvider]
+    [contextValue, Track]
   );
 }

--- a/src/useTracking.js
+++ b/src/useTracking.js
@@ -1,8 +1,9 @@
 import React, { useCallback, useContext, useEffect, useMemo } from 'react';
 import merge from 'deepmerge';
 
-import { ReactTrackingContext } from './withTrackingComponentDecorator';
 import dispatchTrackingEvent from './dispatchTrackingEvent';
+
+export const ReactTrackingContext = React.createContext({});
 
 export default function useTracking(
   trackingData = {},
@@ -93,15 +94,22 @@ export default function useTracking(
     process,
   ]);
 
+  const nextDispatch = useMemo(() => getTrackingDispatcher(), [
+    getTrackingDispatcher,
+  ]);
+  const nextGetTrackingData = useMemo(() => getTrackingDataFn(), [
+    getTrackingDataFn,
+  ]);
+
   const contextValue = useMemo(
     () => ({
       tracking: {
-        dispatch: getTrackingDispatcher(),
-        getTrackingData: getTrackingDataFn(),
+        dispatch: nextDispatch,
+        getTrackingData: nextGetTrackingData,
         process: getProcessFn() || process,
       },
     }),
-    [getTrackingDispatcher, getTrackingDataFn, getProcessFn, process]
+    [nextDispatch, nextGetTrackingData, getProcessFn, process]
   );
 
   const TrackingProvider = useCallback(
@@ -115,10 +123,10 @@ export default function useTracking(
 
   return useMemo(
     () => ({
-      getTrackingData: tracking.getTrackingData,
-      trackEvent: tracking.dispatch,
+      getTrackingData: nextGetTrackingData,
+      trackEvent: nextDispatch,
       Track: TrackingProvider,
     }),
-    [tracking.getTrackingData, tracking.dispatch, TrackingProvider]
+    [nextDispatch, nextGetTrackingData, TrackingProvider]
   );
 }

--- a/src/useTracking.js
+++ b/src/useTracking.js
@@ -1,25 +1,124 @@
-import { useContext, useMemo } from 'react';
-import { ReactTrackingContext } from './withTrackingComponentDecorator';
+import React, { useCallback, useContext, useEffect, useMemo } from 'react';
+import merge from 'deepmerge';
 
-export default function useTracking() {
+import { ReactTrackingContext } from './withTrackingComponentDecorator';
+import dispatchTrackingEvent from './dispatchTrackingEvent';
+
+export default function useTracking(
+  trackingData = {},
+  { dispatch = dispatchTrackingEvent, dispatchOnMount = false, process } = {}
+) {
   const trackingContext = useContext(ReactTrackingContext);
 
-  if (!(trackingContext && trackingContext.tracking)) {
-    throw new Error(
-      'Attempting to call `useTracking` ' +
-        'without a ReactTrackingContext present. Did you forget to wrap the top of ' +
-        'your component tree with `track`?'
-    );
-  }
+  // if (!(trackingContext && trackingContext.tracking)) {
+  //   throw new Error(
+  //     'Attempting to call `useTracking` ' +
+  //       'without a ReactTrackingContext present. Did you forget to wrap the top of ' +
+  //       'your component tree with `track`?'
+  //   );
+  // }
+
+  // statically extract tracking.process for hook dependency
+  const tracking = useMemo(() => trackingContext.tracking || {}, [
+    trackingContext.tracking,
+  ]);
+  const trkProcess = tracking.process;
+  const getProcessFn = useCallback(() => trkProcess, [trkProcess]);
+
+  const getOwnTrackingData = useCallback(() => {
+    const ownTrackingData =
+      typeof trackingData === 'function' ? trackingData() : trackingData;
+    return ownTrackingData || {};
+  }, [trackingData]);
+
+  const getTrackingDataFn = useCallback(() => {
+    const contextGetTrackingData =
+      (tracking && tracking.getTrackingData) || getOwnTrackingData;
+
+    return () =>
+      contextGetTrackingData === getOwnTrackingData
+        ? getOwnTrackingData()
+        : merge(contextGetTrackingData(), getOwnTrackingData());
+  }, [getOwnTrackingData, tracking]);
+
+  const getTrackingDispatcher = useCallback(() => {
+    const contextDispatch = (tracking && tracking.dispatch) || dispatch;
+    return data => contextDispatch(merge(getOwnTrackingData(), data || {}));
+  }, [getOwnTrackingData, tracking, dispatch]);
+
+  const trackEvent = useCallback(
+    (data = {}) => {
+      getTrackingDispatcher()(data);
+    },
+    [getTrackingDispatcher]
+  );
+
+  useEffect(() => {
+    const contextProcess = getProcessFn();
+    const getTrackingData = getTrackingDataFn();
+
+    if (contextProcess && process) {
+      // eslint-disable-next-line
+      console.error(
+        '[react-tracking] options.process should be defined once on a top-level component'
+      );
+    }
+
+    if (
+      typeof contextProcess === 'function' &&
+      typeof dispatchOnMount === 'function'
+    ) {
+      trackEvent(
+        merge(
+          contextProcess(getOwnTrackingData()) || {},
+          dispatchOnMount(getTrackingData()) || {}
+        )
+      );
+    } else if (typeof contextProcess === 'function') {
+      const processed = contextProcess(getOwnTrackingData());
+      if (processed || dispatchOnMount === true) {
+        trackEvent(processed);
+      }
+    } else if (typeof dispatchOnMount === 'function') {
+      trackEvent(dispatchOnMount(getTrackingData()));
+    } else if (dispatchOnMount === true) {
+      trackEvent();
+    }
+  }, [
+    getOwnTrackingData,
+    getProcessFn,
+    getTrackingDataFn,
+    trackEvent,
+    dispatchOnMount,
+    process,
+  ]);
+
+  const contextValue = useMemo(
+    () => ({
+      tracking: {
+        dispatch: getTrackingDispatcher(),
+        getTrackingData: getTrackingDataFn(),
+        process: getProcessFn() || process,
+      },
+    }),
+    [getTrackingDispatcher, getTrackingDataFn, getProcessFn, process]
+  );
+
+  const TrackingProvider = useCallback(
+    ({ children }) => (
+      <ReactTrackingContext.Provider value={contextValue}>
+        {children}
+      </ReactTrackingContext.Provider>
+    ),
+    [contextValue]
+  );
 
   return useMemo(
     () => ({
-      getTrackingData: trackingContext.tracking.getTrackingData,
-      trackEvent: trackingContext.tracking.dispatch,
+      getTrackingData: tracking.getTrackingData,
+      trackEvent: tracking.dispatch,
+      Track: TrackingProvider,
     }),
-    [
-      trackingContext.tracking.getTrackingData,
-      trackingContext.tracking.dispatch,
-    ]
+    [tracking.getTrackingData, tracking.dispatch, TrackingProvider]
   );
 }

--- a/src/useTrackingImpl.js
+++ b/src/useTrackingImpl.js
@@ -1,9 +1,8 @@
-import React, { useCallback, useContext, useEffect, useMemo } from 'react';
+import { useCallback, useContext, useEffect, useMemo } from 'react';
 import merge from 'deepmerge';
 
+import ReactTrackingContext from './ReactTrackingContext';
 import dispatchTrackingEvent from './dispatchTrackingEvent';
-
-export const ReactTrackingContext = React.createContext({});
 
 export default function useTrackingImpl(
   trackingData = {},

--- a/src/useTrackingImpl.js
+++ b/src/useTrackingImpl.js
@@ -17,8 +17,11 @@ export default function useTrackingImpl(trackingData, options) {
     latestOptions.current = options;
   });
 
-  const { dispatch = dispatchTrackingEvent, dispatchOnMount = false, process } =
-    latestOptions.current || {};
+  const {
+    dispatch = dispatchTrackingEvent,
+    dispatchOnMount = false,
+    process,
+  } = useMemo(() => latestOptions.current || {}, []);
 
   const getProcessFn = useCallback(() => tracking && tracking.process, [
     tracking,

--- a/src/useTrackingImpl.js
+++ b/src/useTrackingImpl.js
@@ -1,0 +1,96 @@
+import React, { useCallback, useContext, useEffect, useMemo } from 'react';
+import merge from 'deepmerge';
+
+import dispatchTrackingEvent from './dispatchTrackingEvent';
+
+export const ReactTrackingContext = React.createContext({});
+
+export default function useTrackingImpl(
+  trackingData = {},
+  { dispatch = dispatchTrackingEvent, dispatchOnMount = false, process } = {}
+) {
+  const { tracking } = useContext(ReactTrackingContext);
+
+  const getProcessFn = useCallback(() => tracking && tracking.process, [
+    tracking,
+  ]);
+
+  const getOwnTrackingData = useCallback(() => {
+    const ownTrackingData =
+      typeof trackingData === 'function' ? trackingData() : trackingData;
+    return ownTrackingData || {};
+  }, [trackingData]);
+
+  const getTrackingDataFn = useCallback(() => {
+    const contextGetTrackingData =
+      (tracking && tracking.getTrackingData) || getOwnTrackingData;
+
+    return () =>
+      contextGetTrackingData === getOwnTrackingData
+        ? getOwnTrackingData()
+        : merge(contextGetTrackingData(), getOwnTrackingData());
+  }, [getOwnTrackingData, tracking]);
+
+  const getTrackingDispatcher = useCallback(() => {
+    const contextDispatch = (tracking && tracking.dispatch) || dispatch;
+    return data => contextDispatch(merge(getOwnTrackingData(), data || {}));
+  }, [getOwnTrackingData, tracking, dispatch]);
+
+  const trackEvent = useCallback(
+    (data = {}) => {
+      getTrackingDispatcher()(data);
+    },
+    [getTrackingDispatcher]
+  );
+
+  useEffect(() => {
+    const contextProcess = getProcessFn();
+    const getTrackingData = getTrackingDataFn();
+
+    if (contextProcess && process) {
+      // eslint-disable-next-line
+      console.error(
+        '[react-tracking] options.process should be defined once on a top-level component'
+      );
+    }
+
+    if (
+      typeof contextProcess === 'function' &&
+      typeof dispatchOnMount === 'function'
+    ) {
+      trackEvent(
+        merge(
+          contextProcess(getOwnTrackingData()) || {},
+          dispatchOnMount(getTrackingData()) || {}
+        )
+      );
+    } else if (typeof contextProcess === 'function') {
+      const processed = contextProcess(getOwnTrackingData());
+      if (processed || dispatchOnMount === true) {
+        trackEvent(processed);
+      }
+    } else if (typeof dispatchOnMount === 'function') {
+      trackEvent(dispatchOnMount(getTrackingData()));
+    } else if (dispatchOnMount === true) {
+      trackEvent();
+    }
+  }, [
+    getOwnTrackingData,
+    getProcessFn,
+    getTrackingDataFn,
+    trackEvent,
+    dispatchOnMount,
+    process,
+  ]);
+
+  return useMemo(
+    () => ({
+      tracking: {
+        dispatch: getTrackingDispatcher(),
+        getTrackingData: getTrackingDataFn(),
+        process: getProcessFn() || process,
+      },
+    }),
+    [getTrackingDispatcher, getTrackingDataFn, getProcessFn, process]
+  );
+}

--- a/src/withTrackingComponentDecorator.js
+++ b/src/withTrackingComponentDecorator.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import hoistNonReactStatic from 'hoist-non-react-statics';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 import PropTypes from 'prop-types';
 
 import useTracking from './useTracking';
@@ -63,7 +63,7 @@ export default function withTrackingComponentDecorator(
         React.createElement(WithTracking, { ...props, rtFwdRef: ref })
       );
       forwarded.displayName = `WithTracking(${decoratedComponentName})`;
-      hoistNonReactStatic(forwarded, DecoratedComponent);
+      hoistNonReactStatics(forwarded, DecoratedComponent);
       return forwarded;
     }
 
@@ -76,7 +76,7 @@ export default function withTrackingComponentDecorator(
     };
     WithTracking.defaultProps = { rtFwdRef: undefined };
 
-    hoistNonReactStatic(WithTracking, DecoratedComponent);
+    hoistNonReactStatics(WithTracking, DecoratedComponent);
     return WithTracking;
   };
 }

--- a/src/withTrackingComponentDecorator.js
+++ b/src/withTrackingComponentDecorator.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import hoistNonReactStatic from 'hoist-non-react-statics';
 
 import useTracking from './useTracking';
@@ -22,8 +22,16 @@ export default function withTrackingComponentDecorator(
         latestProps.current = props;
       });
 
+      const trackingDataFn = useCallback(
+        () =>
+          typeof trackingData === 'function'
+            ? trackingData(latestProps.current)
+            : trackingData,
+        []
+      );
+
       const { getTrackingData, trackEvent, Track } = useTracking(
-        trackingData,
+        trackingDataFn,
         options
       );
 

--- a/src/withTrackingComponentDecorator.js
+++ b/src/withTrackingComponentDecorator.js
@@ -1,33 +1,18 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-} from 'react';
-import merge from 'deepmerge';
+import React, { useEffect, useMemo, useRef } from 'react';
 import hoistNonReactStatic from 'hoist-non-react-statics';
 
-import dispatchTrackingEvent from './dispatchTrackingEvent';
-
-export const ReactTrackingContext = React.createContext({});
+import useTracking from './useTracking';
 
 export default function withTrackingComponentDecorator(
   trackingData = {},
-  {
-    dispatch = dispatchTrackingEvent,
-    dispatchOnMount = false,
-    process,
-    forwardRef = false,
-  } = {}
+  { forwardRef = false, ...options } = {}
 ) {
   return DecoratedComponent => {
     const decoratedComponentName =
       DecoratedComponent.displayName || DecoratedComponent.name || 'Component';
 
     function WithTracking({ rtFwdRef, ...props }) {
-      const { tracking } = useContext(ReactTrackingContext);
       const latestProps = useRef(props);
 
       useEffect(() => {
@@ -37,90 +22,17 @@ export default function withTrackingComponentDecorator(
         latestProps.current = props;
       });
 
-      // statically extract tracking.process for hook dependency
-      const trkProcess = tracking && tracking.process;
-      const getProcessFn = useCallback(() => trkProcess, [trkProcess]);
-
-      const getOwnTrackingData = useCallback(() => {
-        const ownTrackingData =
-          typeof trackingData === 'function'
-            ? trackingData(latestProps.current)
-            : trackingData;
-        return ownTrackingData || {};
-      }, []);
-
-      const getTrackingDataFn = useCallback(() => {
-        const contextGetTrackingData =
-          (tracking && tracking.getTrackingData) || getOwnTrackingData;
-
-        return () =>
-          contextGetTrackingData === getOwnTrackingData
-            ? getOwnTrackingData()
-            : merge(contextGetTrackingData(), getOwnTrackingData());
-      }, [getOwnTrackingData, tracking]);
-
-      const getTrackingDispatcher = useCallback(() => {
-        const contextDispatch = (tracking && tracking.dispatch) || dispatch;
-        return data => contextDispatch(merge(getOwnTrackingData(), data || {}));
-      }, [getOwnTrackingData, tracking]);
-
-      const trackEvent = useCallback(
-        (data = {}) => {
-          getTrackingDispatcher()(data);
-        },
-        [getTrackingDispatcher]
+      const { getTrackingData, trackEvent, Track } = useTracking(
+        trackingData,
+        options
       );
-
-      useEffect(() => {
-        const contextProcess = getProcessFn();
-        const getTrackingData = getTrackingDataFn();
-
-        if (getProcessFn() && process) {
-          // eslint-disable-next-line
-          console.error(
-            '[react-tracking] options.process should be defined once on a top-level component'
-          );
-        }
-
-        if (
-          typeof contextProcess === 'function' &&
-          typeof dispatchOnMount === 'function'
-        ) {
-          trackEvent(
-            merge(
-              contextProcess(getOwnTrackingData()) || {},
-              dispatchOnMount(getTrackingData()) || {}
-            )
-          );
-        } else if (typeof contextProcess === 'function') {
-          const processed = contextProcess(getOwnTrackingData());
-          if (processed || dispatchOnMount === true) {
-            trackEvent(processed);
-          }
-        } else if (typeof dispatchOnMount === 'function') {
-          trackEvent(dispatchOnMount(getTrackingData()));
-        } else if (dispatchOnMount === true) {
-          trackEvent();
-        }
-      }, [getOwnTrackingData, getProcessFn, getTrackingDataFn, trackEvent]);
 
       const trackingProp = useMemo(
         () => ({
           trackEvent,
-          getTrackingData: getTrackingDataFn(),
+          getTrackingData,
         }),
-        [trackEvent, getTrackingDataFn]
-      );
-
-      const contextValue = useMemo(
-        () => ({
-          tracking: {
-            dispatch: getTrackingDispatcher(),
-            getTrackingData: getTrackingDataFn(),
-            process: getProcessFn() || process,
-          },
-        }),
-        [getTrackingDispatcher, getTrackingDataFn, getProcessFn]
+        [trackEvent, getTrackingData]
       );
 
       const propsToBePassed = useMemo(
@@ -128,13 +40,10 @@ export default function withTrackingComponentDecorator(
         [props, rtFwdRef]
       );
 
-      return useMemo(
-        () => (
-          <ReactTrackingContext.Provider value={contextValue}>
-            <DecoratedComponent {...propsToBePassed} tracking={trackingProp} />
-          </ReactTrackingContext.Provider>
-        ),
-        [contextValue, trackingProp, propsToBePassed]
+      return (
+        <Track>
+          <DecoratedComponent {...propsToBePassed} tracking={trackingProp} />
+        </Track>
       );
     }
 

--- a/src/withTrackingComponentDecorator.js
+++ b/src/withTrackingComponentDecorator.js
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import PropTypes from 'prop-types';
 
-import useTracking from './useTracking';
+import useTrackingImpl, { ReactTrackingContext } from './useTrackingImpl';
 
 export default function withTrackingComponentDecorator(
   trackingData = {},
@@ -30,17 +30,14 @@ export default function withTrackingComponentDecorator(
         []
       );
 
-      const { getTrackingData, trackEvent, Track } = useTracking(
-        trackingDataFn,
-        options
-      );
+      const contextValue = useTrackingImpl(trackingDataFn, options);
 
       const trackingProp = useMemo(
         () => ({
-          trackEvent,
-          getTrackingData,
+          trackEvent: contextValue.tracking.dispatch,
+          getTrackingData: contextValue.tracking.getTrackingData,
         }),
-        [trackEvent, getTrackingData]
+        [contextValue]
       );
 
       const propsToBePassed = useMemo(
@@ -49,12 +46,12 @@ export default function withTrackingComponentDecorator(
       );
 
       return (
-        <Track>
+        <ReactTrackingContext.Provider value={contextValue}>
           {React.createElement(DecoratedComponent, {
             ...propsToBePassed,
             tracking: trackingProp,
           })}
-        </Track>
+        </ReactTrackingContext.Provider>
       );
     }
 

--- a/src/withTrackingComponentDecorator.js
+++ b/src/withTrackingComponentDecorator.js
@@ -2,7 +2,8 @@ import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import PropTypes from 'prop-types';
 
-import useTrackingImpl, { ReactTrackingContext } from './useTrackingImpl';
+import ReactTrackingContext from './ReactTrackingContext';
+import useTrackingImpl from './useTrackingImpl';
 
 export default function withTrackingComponentDecorator(
   trackingData = {},

--- a/src/withTrackingComponentDecorator.js
+++ b/src/withTrackingComponentDecorator.js
@@ -1,6 +1,6 @@
-/* eslint-disable react/jsx-props-no-spreading */
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import hoistNonReactStatic from 'hoist-non-react-statics';
+import PropTypes from 'prop-types';
 
 import useTracking from './useTracking';
 
@@ -50,21 +50,32 @@ export default function withTrackingComponentDecorator(
 
       return (
         <Track>
-          <DecoratedComponent {...propsToBePassed} tracking={trackingProp} />
+          {React.createElement(DecoratedComponent, {
+            ...propsToBePassed,
+            tracking: trackingProp,
+          })}
         </Track>
       );
     }
 
     if (forwardRef) {
-      const forwarded = React.forwardRef((props, ref) => (
-        <WithTracking {...props} rtFwdRef={ref} />
-      ));
+      const forwarded = React.forwardRef((props, ref) =>
+        React.createElement(WithTracking, { ...props, rtFwdRef: ref })
+      );
       forwarded.displayName = `WithTracking(${decoratedComponentName})`;
       hoistNonReactStatic(forwarded, DecoratedComponent);
       return forwarded;
     }
 
     WithTracking.displayName = `WithTracking(${decoratedComponentName})`;
+    WithTracking.propTypes = {
+      rtFwdRef: PropTypes.oneOfType([
+        PropTypes.func,
+        PropTypes.shape({ current: PropTypes.any }),
+      ]),
+    };
+    WithTracking.defaultProps = { rtFwdRef: undefined };
+
     hoistNonReactStatic(WithTracking, DecoratedComponent);
     return WithTracking;
   };


### PR DESCRIPTION
This PR could probably use more refinement, but I want to get some early feedback on it. It addresses issue https://github.com/nytimes/react-tracking/issues/138. I spent some time considering this API vs having the `Track` component take in props. I think this is the better option because it allows contextual data to be passed into the hook and get back a `trackEvent` function that can make use of that data, which would not be possible if the data had to be passed into the `Track` component instead.

One minor (I think) concern I still have is that it might be too easy for a developer to forget to wrap their markup in the `Track` component, and mistakenly believe that child components are receiving contextual data when they're not. Open question: Would it make any sense to emulate the `useState` API, and do something like:
```js
const [Track, tracking] = useTracking(data);
```
That would at least force the developer to very clearly opt out of using `Track` by needing to do:
```js
const [, tracking] = useTracking(data);
```
Maybe that's too heavy handed though. I don't know—something worth thinking about perhaps.