### PR TITLE
Update docs for expanded useTracking API

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,9 +294,6 @@ class Page1 extends Component {...}
 class Page2 extends Component {...}
 ```
 
-When `Page1` mounts, event with data `{page: 'Page1', event: 'pageview'}` will be dispatched.
-When `Page2` mounts, nothing will be dispatched.
-
 <details>
 <summary>Example using hooks</summary>
 
@@ -327,6 +324,9 @@ function Page2() {
 ```
 
 </details>
+
+When `Page1` mounts, event with data `{page: 'Page1', event: 'pageview'}` will be dispatched.
+When `Page2` mounts, nothing will be dispatched.
 
 ### Tracking Asynchronous Methods
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,11 @@
       "name": "Lukasz Szmit",
       "email": "lukasz.szmit@workday.com",
       "url": "https://github.com/lszm"
+    },
+    {
+      "name": "Bryan Gergen",
+      "email": "bryangergen@gmail.com",
+      "url": "https://github.com/bgergen"
     }
   ],
   "files": [


### PR DESCRIPTION
This updates the docs to account for the enhancements to the `useTracking` API introduced in https://github.com/nytimes/react-tracking/commit/9c941ff1581959f8965247d99a921504224b40b0