### PR TITLE
Widen peer dependency range to include React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,6 @@
   },
   "peerDependencies": {
     "prop-types": "^15.x",
-    "react": "^16.8.0 || ^17"
+    "react": "^16.8.0 || ^17.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -112,6 +112,6 @@
   },
   "peerDependencies": {
     "prop-types": "^15.x",
-    "react": "^16.8"
+    "react": "^16.8.0 || ^17"
   }
 }


### PR DESCRIPTION
This PR aims to widen the peer dependency range to include React 17

Fixes #180 