### PR TITLE
Add drone config

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,61 @@
+kind: pipeline
+type: docker
+name: build node 14
+
+steps:
+  - name: install
+    pull: if-not-exists
+    image: node:14
+    commands:
+      - npm ci
+  
+  - name: prepare
+    image: node:14
+    commands:
+      - npm run prepare
+
+trigger:
+  event:
+    - push
+
+---
+kind: pipeline
+type: docker
+name: build node 12
+
+steps:
+  - name: install
+    pull: if-not-exists
+    image: node:12
+    commands:
+      - npm ci
+
+  - name: prepare
+    image: node:12
+    commands:
+      - npm run prepare
+
+trigger:
+  event:
+    - push
+
+---
+kind: pipeline
+type: docker
+name: build node 10
+
+steps:
+  - name: install
+    pull: if-not-exists
+    image: node:10
+    commands:
+      - npm ci
+
+  - name: prepare
+    image: node:10
+    commands:
+      - npm run prepare
+
+trigger:
+  event:
+    - push

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - 8
-  - 10
-  - 12
-script: npm run prepare


### PR DESCRIPTION
This adds a config that runs on every push to all branches. I saw that the old `.travis.yml` file seemed to be running the `prepare` script for 3 node versions, so I did the same for drone (for node 14, 12, and 10). @tizmagik Does this behavior sound right?