### PR TITLE
Update drone yml to reference main

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,7 +16,7 @@ steps:
 
 trigger:
   branch:
-    - master
+    - main
 
 ---
 kind: pipeline
@@ -37,7 +37,7 @@ steps:
 
 trigger:
   branch:
-    - master
+    - main
 
 ---
 kind: pipeline
@@ -58,4 +58,4 @@ steps:
 
 trigger:
   branch:
-    - master
+    - main


### PR DESCRIPTION
I updated the previously-named `master` primary branch to be named `main`. This updates the drone file to properly reference the new branch name.