### PR TITLE
Take advantage of useDebugValue to display data in devtools

### DIFF
--- a/src/useTracking.js
+++ b/src/useTracking.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useDebugValue, useMemo } from 'react';
 
 import ReactTrackingContext from './ReactTrackingContext';
 import useTrackingImpl from './useTrackingImpl';
@@ -14,6 +14,8 @@ export default function useTracking(trackingData, options) {
     ),
     [contextValue]
   );
+
+  useDebugValue('Tracking Data', contextValue.tracking.getTrackingData);
 
   return useMemo(
     () => ({

--- a/src/useTracking.js
+++ b/src/useTracking.js
@@ -15,7 +15,9 @@ export default function useTracking(trackingData, options) {
     [contextValue]
   );
 
-  useDebugValue('Tracking Data', contextValue.tracking.getTrackingData);
+  useDebugValue(contextValue.tracking.getTrackingData, getTrackingData =>
+    getTrackingData()
+  );
 
   return useMemo(
     () => ({

--- a/src/useTrackingImpl.js
+++ b/src/useTrackingImpl.js
@@ -102,7 +102,7 @@ export default function useTrackingImpl(trackingData, options) {
     process,
   ]);
 
-  useDebugValue('Tracking Data', getTrackingDataFn());
+  useDebugValue(getTrackingDataFn(), getTrackingData => getTrackingData());
 
   return useMemo(
     () => ({

--- a/src/useTrackingImpl.js
+++ b/src/useTrackingImpl.js
@@ -1,4 +1,11 @@
-import { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import {
+  useCallback,
+  useContext,
+  useDebugValue,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 import merge from 'deepmerge';
 
 import ReactTrackingContext from './ReactTrackingContext';
@@ -94,6 +101,8 @@ export default function useTrackingImpl(trackingData, options) {
     dispatchOnMount,
     process,
   ]);
+
+  useDebugValue('Tracking Data', getTrackingDataFn());
 
   return useMemo(
     () => ({

--- a/src/useTrackingImpl.js
+++ b/src/useTrackingImpl.js
@@ -1,11 +1,4 @@
-import {
-  useCallback,
-  useContext,
-  useDebugValue,
-  useEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
 import merge from 'deepmerge';
 
 import ReactTrackingContext from './ReactTrackingContext';
@@ -101,8 +94,6 @@ export default function useTrackingImpl(trackingData, options) {
     dispatchOnMount,
     process,
   ]);
-
-  useDebugValue(getTrackingDataFn(), getTrackingData => getTrackingData());
 
   return useMemo(
     () => ({


### PR DESCRIPTION
We're taking advantage of React's [useDebugValue](https://reactjs.org/docs/hooks-reference.html#usedebugvalue) hook here in order to display contextual tracking data when a user inspects the hook in React devtools. 2 open questions:

1. Is there any other data internal to the library that would be useful to display here?
2. ~Is it necessary for us to call this twice? I like having it in the higher-level `useTracking` hook because it makes it more discoverable. Otherwise, devs would need to inspect the nested `useTrackingImpl` hook in order to discover it. I added it also to `useTrackingImpl` because that makes it visible for components that are using the HoC rather than the hook, since that hook is shared between both. It's redundant, but covers both use cases. Def open to thoughts on this.~ Decided to remove from the `useTrackingImpl` hook—I don't think devs would expect to see it there for a component using the decorator so it probably wouldn't get much use.

### Screenshot
<img width="580" alt="Screen Shot 2022-01-06 at 6 03 23 PM" src="https://user-images.githubusercontent.com/17029672/148464765-992b7476-3848-46cf-99b8-de036d368dd3.png">