### PR TITLE
Enhance e2e test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "build": "babel --out-dir build src --ignore src/__tests__ --source-maps --delete-dir-on-start --minified --no-comments",
     "build:watch": "npm run build -- --watch",
     "lint": "eslint ./src",
-    "prepare": "husky install && npm run lint && npm run test && npm run build",
+    "prepare": "husky install && npm run lint && npm run build && npm run test",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "build": "babel --out-dir build src --ignore src/__tests__ --source-maps --delete-dir-on-start --minified --no-comments",
     "build:watch": "npm run build -- --watch",
     "lint": "eslint ./src",
-    "prepare": "husky install && npm run lint && npm run build && npm run test",
+    "prepare": "husky install && npm run build && npm run lint && npm run test",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch"


### PR DESCRIPTION
Enhance e2e test suite to run against src as well as the built library. This is especially useful in case we upgrade babel or change any babel settings to ensure the transpilation still works as expected for the built artifact.