### PR TITLE
Fix compatibility issue with React Native environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,9 @@ _This is also how you would use this module without `@decorator` syntax, althoug
 
 ### Custom `options.dispatch()` for tracking data
 
-By default, data tracking objects are pushed to `window.dataLayer[]` (see [src/dispatchTrackingEvent.js](src/dispatchTrackingEvent.js)). This is a good default if you use Google Tag Manager. You can override this by passing in a dispatch function as a second parameter to the tracking decorator `{ dispatch: fn() }` on some top-level component high up in your app (typically some root-level component that wraps your entire app).
+By default, data tracking objects are pushed to `window.dataLayer[]` (see [src/dispatchTrackingEvent.js](src/dispatchTrackingEvent.js)). This is a good default if you use Google Tag Manager.
+However, please note that in React Native environments, the window object is undefined as it's specific to web browser environments.
+You can override this by passing in a dispatch function as a second parameter to the tracking decorator `{ dispatch: fn() }` on some top-level component high up in your app (typically some root-level component that wraps your entire app).
 
 For example, to push objects to `window.myCustomDataLayer[]` instead, you would decorate your top-level `<App />` component like this:
 

--- a/src/dispatchTrackingEvent.js
+++ b/src/dispatchTrackingEvent.js
@@ -1,5 +1,5 @@
 export default function dispatchTrackingEvent(data) {
-  if (Object.keys(data).length > 0) {
+  if (typeof window !== 'undefined' && Object.keys(data).length > 0) {
     (window.dataLayer = window.dataLayer || []).push(data);
   }
 }


### PR DESCRIPTION
This is to improve the compatibility with React Native and ensure the dispatch function is triggered correctly.

Currently, the code assumes the availability of the "window" object without checking its type, which is causing an issue with the dispatch function in React Native where "window" is not present. 🙅‍♂️

To fix this, I have added a simple check to ensure the "window" object is defined using typeof window === "undefined". This allows the code to gracefully handle React Native environments and ensures the dispatch function works smoothly in web browser environments. 🚀

Thank you so much for your time and consideration. 🙏