### PR TITLE
Remove defaultProps

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,5 +16,6 @@ module.exports = {
         extensions: ['.js', '.jsx'],
       },
     ],
+    'react/require-default-props': 'off',
   },
 };

--- a/src/withTrackingComponentDecorator.js
+++ b/src/withTrackingComponentDecorator.js
@@ -73,7 +73,6 @@ export default function withTrackingComponentDecorator(
         PropTypes.shape({ current: PropTypes.any }),
       ]),
     };
-    WithTracking.defaultProps = { rtFwdRef: undefined };
 
     hoistNonReactStatics(WithTracking, DecoratedComponent);
     return WithTracking;


### PR DESCRIPTION
Fix for: https://github.com/nytimes/react-tracking/issues/230. I ran the react 19 codemod: `npx codemod react/19/replace-default-props --target src` within the repo.